### PR TITLE
fix(path-checker): resolve workspace aliases and filter URLs

### DIFF
--- a/src/drift/checkers/path.ts
+++ b/src/drift/checkers/path.ts
@@ -1,9 +1,16 @@
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
 import { resolve } from "node:path";
 import { globSync } from "glob";
 import type { Claim, DriftIssue } from "../../types.js";
 
 const PLACEHOLDER_WORDS = /(?:^|[/_-])(?:new|example|your|sample|my|foo|bar|placeholder|template)(?:[/_.-]|$)/i;
+
+/** Scoped package pattern: @scope/name or @scope/name/sub/path */
+const SCOPED_PACKAGE = /^@([\w-]+)\/([\w-]+)(\/.*)?$/;
+
+/** URLs are not filesystem paths */
+const URL_PATTERN = /^https?:\/\//;
 
 /** Check that all claimed paths exist on disk */
 export function checkPaths(
@@ -16,8 +23,14 @@ export function checkPaths(
     (c) => c.kind === "path" && !c.negated
   );
 
+  // Collect workspace package names once for all claims
+  const workspaceNames = collectWorkspaceNames(projectRoot);
+
   for (const claim of pathClaims) {
-    if (pathExists(claim.value, projectRoot, scaffoldRoot)) continue;
+    // URLs are never filesystem paths
+    if (URL_PATTERN.test(claim.value)) continue;
+
+    if (pathExists(claim.value, projectRoot, scaffoldRoot, workspaceNames)) continue;
 
     // Downgrade to warning if: from a pattern file or path contains placeholder words.
     // Bare filenames that aren't found even after recursive search are genuinely missing.
@@ -38,7 +51,55 @@ export function checkPaths(
   return issues;
 }
 
-function pathExists(value: string, projectRoot: string, scaffoldRoot: string): boolean {
+/**
+ * Collect the `name` field from each workspace's package.json.
+ * Works with any package manager (npm, yarn, pnpm, bun) since it reads
+ * the standard `workspaces` field from the root manifest.
+ */
+function collectWorkspaceNames(projectRoot: string): Set<string> {
+  const names = new Set<string>();
+
+  const rootPkgPath = resolve(projectRoot, "package.json");
+  if (!existsSync(rootPkgPath)) return names;
+
+  let rootPkg: { workspaces?: string[] | { packages?: string[] } };
+  try {
+    rootPkg = JSON.parse(readFileSync(rootPkgPath, "utf-8"));
+  } catch {
+    return names;
+  }
+
+  // Normalize workspaces field (array or { packages: [...] })
+  const patterns: string[] = Array.isArray(rootPkg.workspaces)
+    ? rootPkg.workspaces
+    : rootPkg.workspaces?.packages ?? [];
+
+  for (const pattern of patterns) {
+    const dirs = globSync(pattern, {
+      cwd: projectRoot,
+      ignore: ["node_modules/**"],
+    });
+    for (const dir of dirs) {
+      const pkgPath = resolve(projectRoot, dir, "package.json");
+      if (!existsSync(pkgPath)) continue;
+      try {
+        const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+        if (pkg.name) names.add(pkg.name);
+      } catch {
+        // Skip malformed package.json
+      }
+    }
+  }
+
+  return names;
+}
+
+function pathExists(
+  value: string,
+  projectRoot: string,
+  scaffoldRoot: string,
+  workspaceNames: Set<string>
+): boolean {
   // Try project root first (e.g. src/index.ts)
   if (existsSync(resolve(projectRoot, value))) return true;
 
@@ -52,6 +113,25 @@ function pathExists(value: string, projectRoot: string, scaffoldRoot: string): b
   if (value.startsWith(".mex/")) {
     const withoutPrefix = value.slice(".mex/".length);
     if (existsSync(resolve(projectRoot, withoutPrefix))) return true;
+  }
+
+  // Resolve scoped package references (e.g. @acme/ui, @acme/shared/utils)
+  const scopedMatch = value.match(SCOPED_PACKAGE);
+  if (scopedMatch) {
+    const pkgName = `@${scopedMatch[1]}/${scopedMatch[2]}`;
+
+    // Try Node's module resolution first (works for installed npm packages)
+    try {
+      const req = createRequire(resolve(projectRoot, "package.json"));
+      req.resolve(`${pkgName}/package.json`);
+      return true;
+    } catch {
+      // Fall through to workspace check
+    }
+
+    // Check workspace names (handles package managers that don't symlink
+    // all workspaces into node_modules, e.g. bun)
+    if (workspaceNames.has(pkgName)) return true;
   }
 
   // Bare filenames: search recursively — the file may exist in a subdirectory


### PR DESCRIPTION
## Summary

- **Resolve workspace package aliases** in the path checker instead of flagging them as `MISSING_PATH` errors. In monorepos, references like `@acme/ui` or `@acme/shared/utils` in scaffold files are valid import aliases, not filesystem paths.
- **Filter URLs** (`http://`, `https://`) which were being treated as filesystem paths because they contain `/`.

## How it works

1. **`require.resolve` first** — tries Node's built-in module resolution for installed npm packages (handles `node_modules` packages regardless of hoisting strategy)
2. **Workspace name fallback** — reads the root `package.json` `workspaces` field, globs each pattern, and collects the `name` from each workspace's `package.json`. This handles package managers like bun that don't symlink all workspaces into `node_modules/`
3. **URL filter** — skips `http://` and `https://` prefixed values before path checking

## Example

A monorepo with this structure:
```
packages/ui/package.json    → { "name": "@acme/ui" }
packages/shared/package.json → { "name": "@acme/shared" }
```

Previously, scaffold references like `@acme/ui/button` or `@acme/shared/types` would trigger:
```
✗ MISSING_PATH: Referenced path does not exist: @acme/ui/button
```

Now they resolve correctly via the workspace name lookup.

## Test plan

- [x] All 83 existing tests pass
- [x] Build succeeds
- [x] Tested against a real Turborepo + bun monorepo with 8 workspace packages — all `@scope/*` aliases now resolve correctly
- [x] npm packages in `node_modules` still resolve via `require.resolve`
- [x] URLs no longer flagged as missing paths