### PR TITLE
feat: expand KNOWN_RUNTIMES allowlist in dependency checker

### DIFF
--- a/src/drift/checkers/dependency.ts
+++ b/src/drift/checkers/dependency.ts
@@ -2,7 +2,7 @@ import { readFileSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
 import type { Claim, DriftIssue } from "../../types.js";
 
-/** Runtimes, platforms, and databases that appear in stack docs but aren't installable packages */
+/** Runtimes, platforms, databases, protocols, and architectural terms that appear in stack docs but aren't installable packages */
 const KNOWN_RUNTIMES = new Set([
   "node.js", "node", "nodejs",
   "python", "cpython",
@@ -11,14 +11,28 @@ const KNOWN_RUNTIMES = new Set([
   "ruby",
   "java", "jdk", "jre",
   "deno", "bun",
+  "swift", "kotlin", "elixir", "erlang", "php",
+  ".net", "dotnet", "c#", "csharp",
   "sqlite", "sqlite3",
   "postgresql", "postgres",
   "mysql", "mariadb",
   "mongodb", "mongo",
   "redis",
   "elasticsearch",
+  "dynamodb", "cassandra", "neo4j", "supabase", "neon",
   "docker",
   "kubernetes", "k8s",
+  "vercel", "netlify", "railway", "fly.io", "render",
+  "aws", "gcp", "azure", "cloudflare",
+  "s3", "ec2", "lambda", "ecs", "fargate",
+  "rest", "rest api", "graphql", "grpc", "websocket", "websockets",
+  "oauth", "oauth2", "jwt", "saml", "oidc",
+  "http", "https", "tcp", "udp",
+  "tailwind", "tailwind css", "tailwindcss",
+  "bootstrap", "sass", "less", "postcss",
+  "webpack", "vite", "esbuild", "turbopack", "rollup", "parcel",
+  "git", "github", "gitlab", "ci/cd", "nginx", "apache", "caddy",
+  "linux", "macos", "windows", "wasm", "webassembly",
 ]);
 
 /** Check that claimed dependencies exist in manifests */


### PR DESCRIPTION
## Summary

Expands the `KNOWN_RUNTIMES` set in the dependency checker to cover common non-package terms that appear in stack documentation but get false `DEPENDENCY_MISSING` warnings.

## Added terms

- Languages: Swift, Kotlin, Elixir, Erlang, PHP, .NET/C#
- Databases: DynamoDB, Cassandra, Neo4j, Supabase, Neon
- Cloud providers: Vercel, Netlify, Railway, Fly.io, Render, AWS/GCP/Azure/Cloudflare
- AWS services: S3, EC2, Lambda, ECS, Fargate
- Protocols: REST, GraphQL, gRPC, WebSocket, OAuth/JWT/SAML/OIDC
- CSS/Build: Tailwind CSS, Bootstrap, Sass, Webpack, Vite, esbuild, Turbopack
- Infrastructure: Git, GitHub, GitLab, Nginx, Apache, Caddy, Linux, WASM

Fixes #2

This contribution was developed with AI assistance (Claude Code).