### PR TITLE
fix(config): use ROUTER.md as scaffold completeness marker

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -20,8 +20,8 @@ export function findConfig(startDir?: string): MexConfig {
   const projectRoot = gitRoot ?? dir;
 
   const mexDir = resolve(projectRoot, ".mex");
-  if (existsSync(mexDir) && !existsSync(resolve(mexDir, "setup.sh"))) {
-    throw new Error("Scaffold directory exists but looks incomplete. Run: bash .mex/setup.sh");
+  if (existsSync(mexDir) && !existsSync(resolve(mexDir, "ROUTER.md"))) {
+    throw new Error("Scaffold directory exists but looks incomplete. Run: npx mex init");
   }
 
   const scaffoldRoot = findScaffoldRoot(projectRoot);
@@ -31,7 +31,7 @@ export function findConfig(startDir?: string): MexConfig {
     }
 
     throw new Error(
-      "No .mex/ scaffold found. Run: git clone https://github.com/theDakshJaitly/mex.git .mex && bash .mex/setup.sh"
+      "No .mex/ scaffold found. Run: npx mex init"
     );
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,7 +21,7 @@ export function findConfig(startDir?: string): MexConfig {
 
   const mexDir = resolve(projectRoot, ".mex");
   if (existsSync(mexDir) && !existsSync(resolve(mexDir, "ROUTER.md"))) {
-    throw new Error("Scaffold directory exists but looks incomplete. Run: npx mex init");
+    throw new Error("Scaffold directory exists but looks incomplete. Run: mex setup");
   }
 
   const scaffoldRoot = findScaffoldRoot(projectRoot);
@@ -31,7 +31,7 @@ export function findConfig(startDir?: string): MexConfig {
     }
 
     throw new Error(
-      "No .mex/ scaffold found. Run: npx mex init"
+      "No .mex/ scaffold found. Run: mex setup"
     );
   }
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -33,13 +33,13 @@ describe("findConfig", () => {
 
   it("throws when no .mex/ scaffold found at all", () => {
     mkdirSync(join(tmpDir, ".git"));
-    expect(() => findConfig(tmpDir)).toThrow("No .mex/ scaffold found. Run: git clone");
+    expect(() => findConfig(tmpDir)).toThrow("No .mex/ scaffold found. Run: npx mex init");
   });
 
   it("works without .git if a complete scaffold exists", () => {
     const mexPath = join(tmpDir, ".mex");
     mkdirSync(mexPath);
-    writeFileSync(join(mexPath, "setup.sh"), "");
+    writeFileSync(join(mexPath, "ROUTER.md"), "");
     
     const config = findConfig(tmpDir);
     expect(config.projectRoot).toBe(tmpDir);
@@ -58,7 +58,7 @@ describe("findConfig", () => {
     mkdirSync(join(tmpDir, ".git"));
     const mexPath = join(tmpDir, ".mex");
     mkdirSync(mexPath);
-    writeFileSync(join(mexPath, "setup.sh"), "");
+    writeFileSync(join(mexPath, "ROUTER.md"), "");
     mkdirSync(join(tmpDir, "context"));
     const config = findConfig(tmpDir);
     expect(config.scaffoldRoot).toBe(mexPath);

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -33,7 +33,7 @@ describe("findConfig", () => {
 
   it("throws when no .mex/ scaffold found at all", () => {
     mkdirSync(join(tmpDir, ".git"));
-    expect(() => findConfig(tmpDir)).toThrow("No .mex/ scaffold found. Run: npx mex init");
+    expect(() => findConfig(tmpDir)).toThrow("No .mex/ scaffold found. Run: mex setup");
   });
 
   it("works without .git if a complete scaffold exists", () => {


### PR DESCRIPTION
## Summary
- `mex check` was checking for `.mex/setup.sh` as a completeness marker, but `setup.sh` is never copied into the user's `.mex/` directory during init — causing every fresh setup to fail with a misleading error
- Changed the marker to `ROUTER.md`, which is always created by the setup process
- Simplified the "no scaffold found" error message to point to `npx mex init`

Closes #24

## Test plan
- [x] All 85 existing tests pass
- [ ] Run `npx mex init` in a fresh project, then `npx mex check` — should no longer throw the setup.sh error