### PR TITLE
feat: add Nix flake for package distribution

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1775710090,
+        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,76 @@
+{
+  description = "mex - CLI engine for scaffold drift detection, pre-analysis, and targeted sync";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+    in
+    {
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.buildNpmPackage {
+            pname = "mex";
+            version = "0.3.2";
+
+            src = ./.;
+
+            npmDepsHash = "sha256-5gqoL5TeF7giN/qM7VfqY33rutlkmnIbq6FYPBTF3QE=";
+
+            npmBuildScript = "build";
+
+            # Ensure templates directory is included
+            postInstall = ''
+              mkdir -p $out/lib/node_modules/promexeus/templates
+              cp -r templates/* $out/lib/node_modules/promexeus/templates/
+            '';
+
+            meta = with pkgs.lib; {
+              description = "CLI engine for mex scaffold — drift detection, pre-analysis, and targeted sync";
+              homepage = "https://github.com/PJalv/mex";
+              license = licenses.mit;
+              mainProgram = "mex";
+              platforms = supportedSystems;
+            };
+          };
+        });
+
+      overlays.default = final: prev: {
+        mex = self.packages.${final.system}.default;
+      };
+
+      nixosModules.default = { config, lib, pkgs, ... }:
+        let
+          cfg = config.programs.mex;
+        in
+        {
+          options.programs.mex = {
+            enable = lib.mkEnableOption "mex - scaffold drift detection CLI";
+          };
+
+          config = lib.mkIf cfg.enable {
+            environment.systemPackages = [ self.packages.${pkgs.system}.default ];
+          };
+        };
+
+      devShells = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.mkShell {
+            buildInputs = with pkgs; [
+              nodejs_22
+              npm
+            ];
+          };
+        });
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
         {
           default = pkgs.buildNpmPackage {
             pname = "mex";
-            version = "0.3.2";
+            version = "0.4.0";
 
             src = ./.;
 

--- a/flake.nix
+++ b/flake.nix
@@ -68,7 +68,6 @@
           default = pkgs.mkShell {
             buildInputs = with pkgs; [
               nodejs_22
-              npm
             ];
           };
         });


### PR DESCRIPTION
## Summary
- Adds Nix flake for installing `mex` without requiring `npx`
- Enables direct integration into NixOS configurations

## Features
- `buildNpmPackage` derivation for the CLI
- NixOS module for easy system integration (`programs.mex.enable = true`)
- Dev shell with Node.js 22
- Overlay for use in other flakes

## Usage

### NixOS Configuration
```nix
{
  inputs.mex.url = "github:PJalv/mex";
  
  outputs = { nixpkgs, mex, ... }: {
    nixosConfigurations.your-system = nixpkgs.lib.nixosSystem {
      modules = [
        mex.nixosModules.default
        { programs.mex.enable = true; }
      ];
    };
  };
}
```

### Ad-hoc Usage
```bash
nix run github:PJalv/mex
```

### Dev Shell
```bash
nix develop github:PJalv/mex
```