### PR TITLE
feat(drift): make staleness thresholds configurable (#6)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,15 @@
 import chalk from "chalk";
-import { Command } from "commander";
+import { Command, InvalidArgumentError } from "commander";
 import { findConfig } from "./config.js";
 import { reportConsole, reportQuiet, reportJSON, reportVerbose } from "./reporter.js";
+
+function parseIntArg(raw: string): number {
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 0) {
+    throw new InvalidArgumentError(`Expected a non-negative integer, got "${raw}".`);
+  }
+  return n;
+}
 
 const program = new Command();
 
@@ -33,11 +41,27 @@ program
   .option("--quiet", "Single-line summary only")
   .option("--fix", "Run sync to fix any issues found")
   .option("--verbose", "Show detailed diagnostic output")
+  .option("--stale-warn-days <n>", "Warn when a file hasn't changed in N days (default 30)", parseIntArg)
+  .option("--stale-error-days <n>", "Error when a file hasn't changed in N days (default 90)", parseIntArg)
+  .option("--stale-warn-commits <n>", "Warn when a file has N commits since its last change (default 50)", parseIntArg)
+  .option("--stale-error-commits <n>", "Error when a file has N commits since its last change (default 200)", parseIntArg)
   .action(async (opts) => {
     try {
       const config = findConfig();
       const { runDriftCheck } = await import("./drift/index.js");
-      const report = await runDriftCheck(config, { verbose: opts.verbose });
+      const { DEFAULT_STALENESS_THRESHOLDS } = await import("./drift/checkers/staleness.js");
+
+      const stalenessThresholds = {
+        warnDays: opts.staleWarnDays ?? config.stalenessThresholds?.warnDays ?? DEFAULT_STALENESS_THRESHOLDS.warnDays,
+        errorDays: opts.staleErrorDays ?? config.stalenessThresholds?.errorDays ?? DEFAULT_STALENESS_THRESHOLDS.errorDays,
+        warnCommits: opts.staleWarnCommits ?? config.stalenessThresholds?.warnCommits ?? DEFAULT_STALENESS_THRESHOLDS.warnCommits,
+        errorCommits: opts.staleErrorCommits ?? config.stalenessThresholds?.errorCommits ?? DEFAULT_STALENESS_THRESHOLDS.errorCommits,
+      };
+
+      const report = await runDriftCheck(
+        { ...config, stalenessThresholds },
+        { verbose: opts.verbose },
+      );
 
       if (opts.json) {
         reportJSON(report, { verbose: opts.verbose });

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import type { MexConfig, AiTool, StalenessThresholds } from "./types.js";
+import { DEFAULT_STALENESS_THRESHOLDS } from "./drift/checkers/staleness.js";
 
 /**
  * Walk up from startDir looking for .git to find project root,
@@ -103,12 +104,28 @@ function loadStalenessThresholds(scaffoldRoot: string): StalenessThresholds | un
     if (warnDays === undefined && errorDays === undefined && warnCommits === undefined && errorCommits === undefined) {
       return undefined;
     }
-    return {
-      warnDays: warnDays ?? 30,
-      errorDays: errorDays ?? 90,
-      warnCommits: warnCommits ?? 50,
-      errorCommits: errorCommits ?? 200,
+    const resolved: StalenessThresholds = {
+      warnDays: warnDays ?? DEFAULT_STALENESS_THRESHOLDS.warnDays,
+      errorDays: errorDays ?? DEFAULT_STALENESS_THRESHOLDS.errorDays,
+      warnCommits: warnCommits ?? DEFAULT_STALENESS_THRESHOLDS.warnCommits,
+      errorCommits: errorCommits ?? DEFAULT_STALENESS_THRESHOLDS.errorCommits,
     };
+
+    // Reject inverted warn/error pairs. A misconfigured
+    // warnDays: 90, errorDays: 30 silently makes the warn path unreachable,
+    // so surface it and fall back to defaults rather than honoring a
+    // config that disables half of the checker.
+    if (resolved.errorDays < resolved.warnDays || resolved.errorCommits < resolved.warnCommits) {
+      console.warn(
+        `[mex] staleness thresholds in ${configPath} invert warn/error ` +
+          `(warnDays=${resolved.warnDays}, errorDays=${resolved.errorDays}, ` +
+          `warnCommits=${resolved.warnCommits}, errorCommits=${resolved.errorCommits}); ` +
+          `falling back to defaults.`
+      );
+      return { ...DEFAULT_STALENESS_THRESHOLDS };
+    }
+
+    return resolved;
   } catch {
     return undefined;
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { resolve, dirname } from "node:path";
-import type { MexConfig, AiTool } from "./types.js";
+import type { MexConfig, AiTool, StalenessThresholds } from "./types.js";
 
 /**
  * Walk up from startDir looking for .git to find project root,
@@ -36,7 +36,8 @@ export function findConfig(startDir?: string): MexConfig {
   }
 
   const aiTools = loadAiTools(scaffoldRoot);
-  return { projectRoot, scaffoldRoot, aiTools };
+  const stalenessThresholds = loadStalenessThresholds(scaffoldRoot);
+  return { projectRoot, scaffoldRoot, aiTools, stalenessThresholds };
 }
 
 function findProjectRoot(dir: string): string | null {
@@ -57,6 +58,7 @@ const CONFIG_FILE = "config.json";
 
 interface MexPersistedConfig {
   aiTools?: unknown;
+  staleness?: unknown;
   [key: string]: unknown;
 }
 
@@ -73,6 +75,42 @@ function loadAiTools(scaffoldRoot: string): AiTool[] {
     return arr.filter((v): v is AiTool => typeof v === "string" && VALID_AI_TOOLS.has(v));
   } catch {
     return [];
+  }
+}
+
+function loadStalenessThresholds(scaffoldRoot: string): StalenessThresholds | undefined {
+  const configPath = resolve(scaffoldRoot, CONFIG_FILE);
+  if (!existsSync(configPath)) return undefined;
+  try {
+    const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return undefined;
+    const staleness = (raw as MexPersistedConfig).staleness;
+    if (typeof staleness !== "object" || staleness === null || Array.isArray(staleness)) return undefined;
+    const s = staleness as Record<string, unknown>;
+
+    const readInt = (key: string): number | undefined => {
+      const v = s[key];
+      if (typeof v === "number" && Number.isFinite(v) && v >= 0) return v;
+      return undefined;
+    };
+
+    const warnDays = readInt("warnDays");
+    const errorDays = readInt("errorDays");
+    const warnCommits = readInt("warnCommits");
+    const errorCommits = readInt("errorCommits");
+
+    // Any field missing falls back to defaults, so partial overrides still work.
+    if (warnDays === undefined && errorDays === undefined && warnCommits === undefined && errorCommits === undefined) {
+      return undefined;
+    }
+    return {
+      warnDays: warnDays ?? 30,
+      errorDays: errorDays ?? 90,
+      warnCommits: warnCommits ?? 50,
+      errorCommits: errorCommits ?? 200,
+    };
+  } catch {
+    return undefined;
   }
 }
 

--- a/src/drift/checkers/staleness.ts
+++ b/src/drift/checkers/staleness.ts
@@ -1,40 +1,51 @@
 import { daysSinceLastChange, commitsSinceLastChange } from "../../git.js";
-import type { DriftIssue, Severity } from "../../types.js";
+import type { DriftIssue, Severity, StalenessThresholds } from "../../types.js";
 
-const WARN_DAYS = 30;
-const ERROR_DAYS = 90;
-const WARN_COMMITS = 50;
-const ERROR_COMMITS = 200;
+/** Default thresholds. Overridden via MexConfig.stalenessThresholds / CLI flags. */
+export const DEFAULT_STALENESS_THRESHOLDS: StalenessThresholds = {
+  warnDays: 30,
+  errorDays: 90,
+  warnCommits: 50,
+  errorCommits: 200,
+};
 
 type StaleSignal = { severity: Severity; message: string };
 
-function daysSignal(days: number): StaleSignal | null {
-  if (days >= ERROR_DAYS) {
+function daysSignal(
+  days: number,
+  warnDays: number,
+  errorDays: number
+): StaleSignal | null {
+  if (days >= errorDays) {
     return {
       severity: "error",
-      message: `File hasn't been updated in ${days} days (threshold: ${ERROR_DAYS}d)`,
+      message: `File hasn't been updated in ${days} days (threshold: ${errorDays}d)`,
     };
   }
-  if (days >= WARN_DAYS) {
+  if (days >= warnDays) {
     return {
       severity: "warning",
-      message: `File hasn't been updated in ${days} days (threshold: ${WARN_DAYS}d)`,
+      message: `File hasn't been updated in ${days} days (threshold: ${warnDays}d)`,
     };
   }
   return null;
 }
 
-function commitsSignal(commits: number): StaleSignal | null {
-  if (commits >= ERROR_COMMITS) {
+function commitsSignal(
+  commits: number,
+  warnCommits: number,
+  errorCommits: number
+): StaleSignal | null {
+  if (commits >= errorCommits) {
     return {
       severity: "error",
-      message: `${commits} commits since file was last updated (threshold: ${ERROR_COMMITS})`,
+      message: `${commits} commits since file was last updated (threshold: ${errorCommits})`,
     };
   }
-  if (commits >= WARN_COMMITS) {
+  if (commits >= warnCommits) {
     return {
       severity: "warning",
-      message: `${commits} commits since file was last updated (threshold: ${WARN_COMMITS})`,
+      message: `${commits} commits since file was last updated (threshold: ${warnCommits})`,
     };
   }
   return null;
@@ -57,18 +68,21 @@ const SEVERITY_RANK: Record<Severity, number> = {
 export async function checkStaleness(
   filePath: string,
   source: string,
-  cwd: string
+  cwd: string,
+  thresholds: StalenessThresholds = DEFAULT_STALENESS_THRESHOLDS
 ): Promise<DriftIssue[]> {
+  const { warnDays, errorDays, warnCommits, errorCommits } = thresholds;
+
   const days = await daysSinceLastChange(filePath, cwd);
   const commits = await commitsSinceLastChange(filePath, cwd);
 
   const signals: StaleSignal[] = [];
   if (days !== null) {
-    const s = daysSignal(days);
+    const s = daysSignal(days, warnDays, errorDays);
     if (s) signals.push(s);
   }
   if (commits !== null) {
-    const s = commitsSignal(commits);
+    const s = commitsSignal(commits, warnCommits, errorCommits);
     if (s) signals.push(s);
   }
 

--- a/src/drift/index.ts
+++ b/src/drift/index.ts
@@ -44,7 +44,12 @@ export async function runDriftCheck(
     allIssues.push(...edgeIssues);
 
     // Staleness check
-    const stalenessIssues = await checkStaleness(source, source, projectRoot);
+    const stalenessIssues = await checkStaleness(
+      source,
+      source,
+      projectRoot,
+      config.stalenessThresholds,
+    );
     allIssues.push(...stalenessIssues);
 
     checkerIssueCounts.push([`edges:${source}`, edgeIssues.length]);

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,17 @@ export const AI_TOOLS: Record<AiTool, AiToolMeta> = {
 
 // ── Config ──
 
+export interface StalenessThresholds {
+  /** Days since last change that trigger a warning */
+  warnDays: number;
+  /** Days since last change that trigger an error */
+  errorDays: number;
+  /** Commits since last change that trigger a warning */
+  warnCommits: number;
+  /** Commits since last change that trigger an error */
+  errorCommits: number;
+}
+
 export interface MexConfig {
   /** Absolute path to project root (where .git lives) */
   projectRoot: string;
@@ -29,6 +40,8 @@ export interface MexConfig {
   scaffoldRoot: string;
   /** Which AI tool(s) the user selected during setup */
   aiTools: AiTool[];
+  /** Staleness thresholds (warn/error for days and commits). Optional. */
+  stalenessThresholds?: StalenessThresholds;
 }
 
 // ── Claims (extracted from markdown) ──

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -84,6 +84,80 @@ describe("findConfig", () => {
   });
 });
 
+describe("findConfig — stalenessThresholds", () => {
+  function setupScaffold(staleness: unknown): void {
+    mkdirSync(join(tmpDir, ".git"));
+    const mexPath = join(tmpDir, ".mex");
+    mkdirSync(mexPath);
+    writeFileSync(join(mexPath, "ROUTER.md"), "");
+    writeFileSync(join(mexPath, "config.json"), JSON.stringify({ staleness }));
+  }
+
+  it("loads full thresholds from config.json", () => {
+    setupScaffold({ warnDays: 14, errorDays: 60, warnCommits: 25, errorCommits: 100 });
+    const config = findConfig(tmpDir);
+    expect(config.stalenessThresholds).toEqual({
+      warnDays: 14,
+      errorDays: 60,
+      warnCommits: 25,
+      errorCommits: 100,
+    });
+  });
+
+  it("fills missing fields from the checker defaults", () => {
+    setupScaffold({ warnDays: 14 });
+    const config = findConfig(tmpDir);
+    expect(config.stalenessThresholds).toEqual({
+      warnDays: 14,
+      errorDays: 90,
+      warnCommits: 50,
+      errorCommits: 200,
+    });
+  });
+
+  it("warns and falls back to defaults when warn exceeds error", () => {
+    setupScaffold({ warnDays: 90, errorDays: 30 });
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (msg: string) => {
+      warnings.push(msg);
+    };
+    try {
+      const config = findConfig(tmpDir);
+      expect(config.stalenessThresholds).toEqual({
+        warnDays: 30,
+        errorDays: 90,
+        warnCommits: 50,
+        errorCommits: 200,
+      });
+      expect(warnings.some((w) => w.includes("invert warn/error"))).toBe(true);
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  it("warns when commit invariant is violated too", () => {
+    setupScaffold({ warnCommits: 500, errorCommits: 100 });
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (msg: string) => {
+      warnings.push(msg);
+    };
+    try {
+      const config = findConfig(tmpDir);
+      expect(config.stalenessThresholds).toEqual({
+        warnDays: 30,
+        errorDays: 90,
+        warnCommits: 50,
+        errorCommits: 200,
+      });
+      expect(warnings).toHaveLength(1);
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+});
+
 describe("saveAiTools", () => {
   it("creates config.json with aiTools", () => {
     const mexPath = join(tmpDir, ".mex");

--- a/test/staleness.test.ts
+++ b/test/staleness.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the git helpers BEFORE importing the checker so it picks up the stubs.
+vi.mock("../src/git.js", () => ({
+  daysSinceLastChange: vi.fn(),
+  commitsSinceLastChange: vi.fn(),
+}));
+
+const { daysSinceLastChange, commitsSinceLastChange } = await import("../src/git.js");
+const { checkStaleness, DEFAULT_STALENESS_THRESHOLDS } = await import("../src/drift/checkers/staleness.js");
+
+const asMock = <T extends (...args: unknown[]) => unknown>(fn: T) =>
+  fn as unknown as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  asMock(daysSinceLastChange).mockReset();
+  asMock(commitsSinceLastChange).mockReset();
+});
+
+describe("checkStaleness — defaults", () => {
+  it("defaults to 30d warn / 90d error / 50c warn / 200c error", () => {
+    expect(DEFAULT_STALENESS_THRESHOLDS).toEqual({
+      warnDays: 30,
+      errorDays: 90,
+      warnCommits: 50,
+      errorCommits: 200,
+    });
+  });
+
+  it("emits no issues when the file is fresh", async () => {
+    asMock(daysSinceLastChange).mockResolvedValue(5);
+    asMock(commitsSinceLastChange).mockResolvedValue(10);
+
+    const issues = await checkStaleness("a.md", "a.md", "/tmp/repo");
+    expect(issues).toEqual([]);
+  });
+
+  it("collapses day + commit warnings into one combined issue at the default thresholds", async () => {
+    asMock(daysSinceLastChange).mockResolvedValue(31);
+    asMock(commitsSinceLastChange).mockResolvedValue(60);
+
+    const issues = await checkStaleness("a.md", "a.md", "/tmp/repo");
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({ severity: "warning", code: "STALE_FILE" });
+    expect(issues[0].message).toContain("31 days");
+    expect(issues[0].message).toContain("60 commits");
+  });
+
+  it("collapses day + commit errors into one combined issue at the default thresholds", async () => {
+    asMock(daysSinceLastChange).mockResolvedValue(120);
+    asMock(commitsSinceLastChange).mockResolvedValue(300);
+
+    const issues = await checkStaleness("a.md", "a.md", "/tmp/repo");
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({ severity: "error" });
+    expect(issues[0].message).toContain("threshold: 90d");
+    expect(issues[0].message).toContain("threshold: 200");
+  });
+});
+
+describe("checkStaleness — custom thresholds", () => {
+  it("respects a tighter warn threshold (14d)", async () => {
+    asMock(daysSinceLastChange).mockResolvedValue(15);
+    asMock(commitsSinceLastChange).mockResolvedValue(0);
+
+    const issues = await checkStaleness("a.md", "a.md", "/tmp/repo", {
+      warnDays: 14,
+      errorDays: 30,
+      warnCommits: 20,
+      errorCommits: 50,
+    });
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({ severity: "warning" });
+    expect(issues[0].message).toContain("15 days");
+    expect(issues[0].message).toContain("threshold: 14d");
+  });
+
+  it("respects a tighter error threshold (30d)", async () => {
+    asMock(daysSinceLastChange).mockResolvedValue(45);
+    asMock(commitsSinceLastChange).mockResolvedValue(0);
+
+    const issues = await checkStaleness("a.md", "a.md", "/tmp/repo", {
+      warnDays: 14,
+      errorDays: 30,
+      warnCommits: 20,
+      errorCommits: 50,
+    });
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({ severity: "error" });
+    expect(issues[0].message).toContain("threshold: 30d");
+  });
+
+  it("respects tighter commit thresholds", async () => {
+    asMock(daysSinceLastChange).mockResolvedValue(0);
+    asMock(commitsSinceLastChange).mockResolvedValue(25);
+
+    const issues = await checkStaleness("a.md", "a.md", "/tmp/repo", {
+      warnDays: 999,
+      errorDays: 9999,
+      warnCommits: 20,
+      errorCommits: 50,
+    });
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({ severity: "warning" });
+    expect(issues[0].message).toContain("threshold: 20");
+  });
+
+  it("is silent when custom thresholds raise the bar above reality", async () => {
+    asMock(daysSinceLastChange).mockResolvedValue(60);
+    asMock(commitsSinceLastChange).mockResolvedValue(150);
+
+    const issues = await checkStaleness("a.md", "a.md", "/tmp/repo", {
+      warnDays: 90,
+      errorDays: 180,
+      warnCommits: 200,
+      errorCommits: 500,
+    });
+    expect(issues).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #6.

## Summary

Thresholds used by the staleness checker (`warnDays` / `errorDays` / `warnCommits` / `errorCommits`) were hardcoded at 30 / 90 / 50 / 200. Fast-moving projects want a tighter bar; stable projects want a looser one. They're now configurable via three precedence layers (highest first):

1. **CLI flags** on `mex check`:
   - `--stale-warn-days <n>` / `--stale-error-days <n>`
   - `--stale-warn-commits <n>` / `--stale-error-commits <n>`
2. **Config file** (`.mex/config.json`) under a new `staleness` key:
   ```json
   { "aiTools": ["claude"], "staleness": { "warnDays": 14, "errorDays": 30 } }
   ```
   Partial overrides are allowed — any missing field falls back to the default.
3. **Defaults** — exported as `DEFAULT_STALENESS_THRESHOLDS` (30 / 90 / 50 / 200), unchanged from the previous constants.

## Why four flags, not two

The issue's example (`--stale-days 14 --stale-commits 20`) suggests two knobs, but the checker has four thresholds (warn + error for each of days and commits) and the relationship between them isn't a clean multiplier (90/30=3, 200/50=4). Exposing all four keeps the CLI honest and lets users tighten just the warn bar without moving the error bar. Happy to collapse to two if you'd prefer — the shape of the data flow is unchanged either way.

## Internals

- `StalenessThresholds` added to `src/types.ts`.
- `MexConfig.stalenessThresholds` is optional; `findConfig` loads it from `.mex/config.json` via a new `loadStalenessThresholds` helper that validates each field as a non-negative number and falls back to defaults for any missing field.
- `checkStaleness(...)` takes thresholds as an optional fourth arg, default `DEFAULT_STALENESS_THRESHOLDS`.
- `runDriftCheck` threads `config.stalenessThresholds` through to the checker.
- `mex check` validates flag values via commander's `InvalidArgumentError` so `--stale-warn-days foo` fails fast with a clear message.

## Tests

`test/staleness.test.ts` — 8 new cases, all passing:

- `DEFAULT_STALENESS_THRESHOLDS` exports the documented defaults (30/90/50/200).
- Silent when the file is fresh.
- Warnings at the default warn bar (31d / 60c).
- Errors at the default error bar (120d / 300c), with thresholds printed in the message.
- Custom `warnDays=14` triggers at 15d with a `threshold: 14d` message.
- Custom `errorDays=30` triggers at 45d with a `threshold: 30d` message.
- Custom commit-only thresholds isolate from day thresholds.
- Silent when custom thresholds are raised above the reality.

All 102 tests pass. `npm run typecheck` and `npm run build` also succeed.

## Not in scope

- Exposing thresholds to `mex setup` / `mex sync`. If you want `mex setup` to prompt for staleness preferences, that's a separate UX change.
- Per-file overrides. Current config is repo-wide.