### PR TITLE
feat(drift): add tool-config-sync checker

### DIFF
--- a/src/drift/checkers/tool-config-sync.ts
+++ b/src/drift/checkers/tool-config-sync.ts
@@ -1,0 +1,50 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { DriftIssue } from "../../types.js";
+
+/**
+ * Files that `setup.sh` may copy with identical content from `.tool-configs/`.
+ * If a user installs more than one tool and later edits one of these files in
+ * place, the copies can silently drift out of sync. `.opencode/opencode.json`
+ * is intentionally excluded -- it's a different format and references
+ * `.mex/AGENTS.md` rather than embedding the same text.
+ */
+const TOOL_CONFIG_FILES: ReadonlyArray<string> = [
+	"CLAUDE.md",
+	"AGENTS.md",
+	".cursorrules",
+	".windsurfrules",
+	".github/copilot-instructions.md",
+];
+
+/** Check that all installed tool config files hold identical content. */
+export function checkToolConfigSync(projectRoot: string): DriftIssue[] {
+	const present: Array<{ path: string; content: string }> = [];
+	for (const rel of TOOL_CONFIG_FILES) {
+		const abs = resolve(projectRoot, rel);
+		if (!existsSync(abs)) continue;
+		try {
+			present.push({ path: rel, content: readFileSync(abs, "utf-8") });
+		} catch {
+			// Unreadable file -- ignore rather than reporting a checker-internal error.
+		}
+	}
+
+	// Nothing to compare until at least two tool configs are installed.
+	if (present.length < 2) return [];
+
+	const reference = present[0];
+	const issues: DriftIssue[] = [];
+	for (let i = 1; i < present.length; i++) {
+		if (present[i].content !== reference.content) {
+			issues.push({
+				code: "TOOL_CONFIG_DRIFT",
+				severity: "warning",
+				file: present[i].path,
+				line: null,
+				message: `Tool config ${present[i].path} has drifted from ${reference.path}. Re-copy from .tool-configs/ or edit both to match.`,
+			});
+		}
+	}
+	return issues;
+}

--- a/src/drift/index.ts
+++ b/src/drift/index.ts
@@ -13,6 +13,7 @@ import { checkCommands } from "./checkers/command.js";
 import { checkDependencies } from "./checkers/dependency.js";
 import { checkCrossFile } from "./checkers/cross-file.js";
 import { checkScriptCoverage } from "./checkers/script-coverage.js";
+import { checkToolConfigSync } from "./checkers/tool-config-sync.js";
 
 /** Run full drift detection across all scaffold files */
 export async function runDriftCheck(
@@ -82,6 +83,10 @@ export async function runDriftCheck(
   const scriptCoverageIssues = checkScriptCoverage(scaffoldFiles, projectRoot);
   allIssues.push(...scriptCoverageIssues);
   checkerIssueCounts.push(["script-coverage", scriptCoverageIssues.length]);
+
+  const toolConfigSyncIssues = checkToolConfigSync(projectRoot);
+  allIssues.push(...toolConfigSyncIssues);
+  checkerIssueCounts.push(["tool-config-sync", toolConfigSyncIssues.length]);
 
   const score = computeScore(allIssues);
   const verboseLog = opts.verbose

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,7 +75,8 @@ export type IssueCode =
   | "DEAD_EDGE"
   | "INDEX_MISSING_ENTRY"
   | "INDEX_ORPHAN_ENTRY"
-  | "UNDOCUMENTED_SCRIPT";
+  | "UNDOCUMENTED_SCRIPT"
+  | "TOOL_CONFIG_DRIFT";
 
 export interface DriftIssue {
   code: IssueCode;

--- a/test/checkers.test.ts
+++ b/test/checkers.test.ts
@@ -13,6 +13,7 @@ import { checkCommands } from "../src/drift/checkers/command.js";
 import { checkDependencies } from "../src/drift/checkers/dependency.js";
 import { checkCrossFile } from "../src/drift/checkers/cross-file.js";
 import { checkIndexSync } from "../src/drift/checkers/index-sync.js";
+import { checkToolConfigSync } from "../src/drift/checkers/tool-config-sync.js";
 import type { Claim, ScaffoldFrontmatter } from "../src/types.js";
 
 vi.mock("../src/git.js", () => ({
@@ -366,5 +367,60 @@ describe("checkStaleness", () => {
     commitsFn.mockResolvedValue(null);
     const issues = await checkStaleness("file.md", "source.md", ".");
     expect(issues).toHaveLength(0);
+  });
+});
+
+// ── Tool Config Sync Checker ──
+
+describe("checkToolConfigSync", () => {
+  it("returns empty when no tool configs are installed", () => {
+    const issues = checkToolConfigSync(tmpDir);
+    expect(issues).toHaveLength(0);
+  });
+
+  it("returns empty when only one tool config is installed", () => {
+    writeFileSync(join(tmpDir, "CLAUDE.md"), "pointer to ROUTER.md");
+    const issues = checkToolConfigSync(tmpDir);
+    expect(issues).toHaveLength(0);
+  });
+
+  it("returns empty when installed tool configs all match", () => {
+    const body = "pointer to ROUTER.md\nsame for every tool\n";
+    writeFileSync(join(tmpDir, "CLAUDE.md"), body);
+    writeFileSync(join(tmpDir, ".cursorrules"), body);
+    writeFileSync(join(tmpDir, ".windsurfrules"), body);
+    const issues = checkToolConfigSync(tmpDir);
+    expect(issues).toHaveLength(0);
+  });
+
+  it("flags drift between two installed tool configs", () => {
+    writeFileSync(join(tmpDir, "CLAUDE.md"), "original\n");
+    writeFileSync(join(tmpDir, ".cursorrules"), "original\nedited\n");
+    const issues = checkToolConfigSync(tmpDir);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe("TOOL_CONFIG_DRIFT");
+    expect(issues[0].severity).toBe("warning");
+    expect(issues[0].file).toBe(".cursorrules");
+    expect(issues[0].message).toContain("CLAUDE.md");
+  });
+
+  it("flags each drifted file separately and leaves matching files alone", () => {
+    writeFileSync(join(tmpDir, "CLAUDE.md"), "v1\n");
+    writeFileSync(join(tmpDir, "AGENTS.md"), "v1\n");           // matches CLAUDE.md
+    writeFileSync(join(tmpDir, ".cursorrules"), "v2 drifted\n"); // drifted
+    writeFileSync(join(tmpDir, ".windsurfrules"), "v3 also\n");  // drifted
+    const issues = checkToolConfigSync(tmpDir);
+    const files = issues.map((i) => i.file).sort();
+    expect(files).toEqual([".cursorrules", ".windsurfrules"]);
+    expect(issues.every((i) => i.code === "TOOL_CONFIG_DRIFT")).toBe(true);
+  });
+
+  it("picks up the Copilot config nested under .github", () => {
+    mkdirSync(join(tmpDir, ".github"), { recursive: true });
+    writeFileSync(join(tmpDir, "CLAUDE.md"), "shared\n");
+    writeFileSync(join(tmpDir, ".github/copilot-instructions.md"), "changed\n");
+    const issues = checkToolConfigSync(tmpDir);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].file).toBe(".github/copilot-instructions.md");
   });
 });


### PR DESCRIPTION
Fixes #8

## What changed

`setup.sh` copies identical content to `CLAUDE.md`, `AGENTS.md`, `.cursorrules`, `.windsurfrules`, and `.github/copilot-instructions.md`. If someone installs more than one tool and then edits one of those files in place, the copies silently drift. Nothing in `mex check` surfaced that before.

Adds a structural checker at `src/drift/checkers/tool-config-sync.ts`:

- Scans the project root for those five files.
- Returns a `TOOL_CONFIG_DRIFT` warning for any file that doesn't match the first one seen.
- No-op when fewer than two are installed.
- Intentionally excludes `.opencode/opencode.json` — per `.tool-configs/README.md`, that file is a different format pointing at `.mex/AGENTS.md` rather than sharing content with the others.

Wired into `runDriftCheck()` next to the existing structural checkers (`index-sync`, `script-coverage`). `TOOL_CONFIG_DRIFT` added to the `IssueCode` union.

## Tests

6 new cases in `test/checkers.test.ts`:

- empty when no tool configs installed
- empty when only one is installed
- empty when all matching
- drift flagged when two differ (right file, right code, right severity)
- multiple drifted files reported separately, matching files left alone
- nested `.github/copilot-instructions.md` is picked up

Full suite: `npx vitest run` → 118 tests passing.

## Out of scope

Left `mex sync-configs` (the "bonus" suggestion in the issue) out of this PR so the checker can land standalone. Happy to follow up if the checker looks good.
