### PR TITLE
docs: add Windows / WSL note to README install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ You can install globally later at any time:
 npm install -g promexeus
 ```
 
+### Windows
+
+The recommended `npx promexeus setup` flow runs in any terminal (Command Prompt, PowerShell, or WSL) and does not need bash, so most Windows users do not have to think about this section.
+
+If you previously installed via the legacy `setup.sh` script, do not mix environments. Building inside WSL and then running the CLI from a native Windows terminal causes "module not found" errors because `node_modules` and path resolution differ between the two filesystems. Run install, build, and CLI commands inside the same environment: either entirely in WSL / Git Bash, or entirely in native Windows via `npx promexeus`.
+
+See [issue #10](https://github.com/theDakshJaitly/mex/issues/10) for context.
+
 ## Drift Detection
 
 Eight checkers validate your scaffold against the real codebase. Zero tokens, zero AI.


### PR DESCRIPTION
## Summary

Closes #10.

Adds a short `### Windows` subsection to the README's `## Install` section. It documents the mitigation the maintainer flagged in the issue thread: `npx promexeus setup` works in any terminal and avoids the WSL/Windows path mismatch entirely. For users on the legacy `setup.sh` flow, a one-paragraph warning explains the "module not found" error and tells them to keep install/build/CLI inside one environment.

This addresses the first checkbox in #10. The other two checkboxes (native Windows setup path, native Windows CLI testing) require Windows infrastructure and are out of scope for a docs PR.

## Files changed

- `README.md` — adds an 8-line `### Windows` subsection between the global-install block and `## Drift Detection`. Existing prose and code blocks are unchanged.

## Test plan

- [x] No code changes
- [x] Existing install commands and headings unchanged
- [x] New section follows the README's existing tone (informal, direct)
- [x] Link to #10 for context