### PR TITLE
Release v0.3 operational memory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.5] - 2026-05-14
+
+### Added
+- **Agent memory mode** — `mex setup --mode agent-memory` creates templates for persistent-agent, homelab, OpenClaw-style, and operational-memory workspaces.
+- **Heartbeat checks** — `mex heartbeat` runs lightweight scheduled health checks over optional `last_updated` frontmatter, stale context, memory cleanup metadata, and old daily memory files.
+- **Scheduled heartbeat loop** — `mex watch --interval` runs heartbeat repeatedly in the foreground while preserving the existing post-commit hook behavior for plain `mex watch`.
+- **Event log** — `mex log` appends notes, decisions, risks, and todos to `.mex/events/decisions.jsonl`.
+- **Timeline** — `mex timeline` reads recent event entries, with `--json` for scripting.
+- **Doctor command** — `mex doctor` summarizes scaffold health across drift, heartbeat, config, and events.
+- **Interactive TUI** — bare `mex` and `mex tui` open an Ink terminal dashboard with drift score, heartbeat status, event activity, timeline/log actions, and a bordered action panel.
+- **Shell completions** — `mex completion bash|zsh|fish` prints completion scripts.
+- **Config tuning** — optional `.mex/config.json` supports staleness thresholds, heartbeat thresholds, and watch interval defaults.
+
+### Changed
+- `mex check` output is grouped by severity with clearer remediation hints.
+- `mex check --json` provides a script-friendly report shape.
+- Scaffold templates now include `last_updated` frontmatter guidance and a GROW loop that encourages logging rationale with `mex log`.
+- Agent-memory templates frame mex as three-layer memory: state memory in scaffold files, procedural memory in patterns, and event memory in JSONL logs.
+- README documents the TUI, agent-memory mode, heartbeat, config, and the OpenClaw/persistent-agent use case.
+
+### Compatibility
+- No scaffold migration is required.
+- `last_updated` is optional; files without it are ignored by heartbeat staleness checks.
+- `.mex/config.json` is optional; missing values use defaults.
+- `.mex/events/` is created only when events are logged.
+- The TUI is additive; all existing CLI commands remain available and script-friendly.
+
+### Deferred
+- Context routing command.
+- Full schema migration with ids/requires fields.
+- Federation / hierarchical scaffolds.
+- Bidirectional state-event references.
+- Dynamic domain nodes via Tree-sitter.
+
 ## [0.4.0] - 2026-04-07
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ All notable changes to this project will be documented in this file.
 - Bidirectional state-event references.
 - Dynamic domain nodes via Tree-sitter.
 
-## [0.4.0] - 2026-04-07
+## [0.3.4] - 2026-04-07
 
 ### Changed
 - **Simplified install flow** — `npx promexeus setup` now offers to install globally at the end, so `mex check` and `mex sync` just work

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ All commands run from your **project root**. If you didn't install globally, rep
 
 | Command | What it does |
 |---------|-------------|
+| `mex` | Open the interactive terminal dashboard |
+| `mex tui` | Open the interactive terminal dashboard explicitly |
 | `mex setup` | First-time setup — create `.mex/` scaffold and populate with AI |
 | `mex setup --mode agent-memory` | Create templates for persistent-agent / homelab memory workspaces |
 | `mex setup --dry-run` | Preview what setup would do without making changes |

--- a/README.md
+++ b/README.md
@@ -98,8 +98,9 @@ All commands run from your **project root**. If you didn't install globally, rep
 | Command | What it does |
 |---------|-------------|
 | `mex setup` | First-time setup — create `.mex/` scaffold and populate with AI |
+| `mex setup --mode agent-memory` | Create templates for persistent-agent / homelab memory workspaces |
 | `mex setup --dry-run` | Preview what setup would do without making changes |
-| `mex check` | Run all 8 checkers, output drift score and issues |
+| `mex check` | Run drift checkers, output drift score and categorized issues |
 | `mex check --quiet` | One-liner: `mex: drift score 92/100 (1 warning)` |
 | `mex check --json` | Full report as JSON for programmatic use |
 | `mex check --fix` | Check and jump straight to sync if errors found |
@@ -108,8 +109,14 @@ All commands run from your **project root**. If you didn't install globally, rep
 | `mex sync --warnings` | Include warning-only files in sync |
 | `mex init` | Pre-scan codebase, build structured brief for AI |
 | `mex init --json` | Raw scanner brief as JSON |
+| `mex log <message>` | Append a note, decision, risk, or todo to `.mex/events/decisions.jsonl` |
+| `mex timeline` | View recent event log entries |
+| `mex heartbeat` | Run lightweight persistent-agent health checks once |
+| `mex doctor` | Friendly scaffold health summary |
 | `mex watch` | Install post-commit hook (silent on perfect score) |
+| `mex watch --interval` | Run heartbeat repeatedly in the foreground |
 | `mex watch --uninstall` | Remove the hook |
+| `mex completion <shell>` | Print bash, zsh, or fish completions |
 | `mex commands` | List all commands and scripts with descriptions |
 
 
@@ -190,12 +197,46 @@ context file → points to pattern file if task-specific guidance exists
     ↓
 Agent executes with full project context, minimal token cost
     ↓
-After task: agent updates scaffold (GROW step)
+After task: agent runs GROW
     ↓
 New patterns, updated project state — scaffold grows from real work
 ```
 
-CLAUDE.md stays at ~120 tokens. The agent navigates to only what it needs. After every task, the agent updates the scaffold — creating patterns from new task types, updating project state, fixing stale context. The scaffold compounds over time.
+CLAUDE.md stays small. The agent navigates to only what it needs. After meaningful work, it runs GROW: Ground what changed, Record current truth in the scaffold, Orient by creating or refining a pattern, and Write `last_updated` plus `mex log` entries when rationale matters.
+
+## Agent Memory Mode
+
+`mex setup --mode agent-memory` creates a scaffold for persistent agents whose "project" is an operational environment rather than a code repo. It adds a `HEARTBEAT.md` contract and templates that frame mex as structured, task-routed memory:
+
+- `ROUTER.md` tracks current operational state and routes the agent to the right memory files.
+- `context/` stores architecture, stack, conventions, setup, and decisions.
+- `patterns/` stores recurring runbooks.
+- `.mex/events/decisions.jsonl` stores append-only notes and rationale via `mex log`.
+
+`mex heartbeat` is intentionally lighter than `mex check`: it reads `last_updated` frontmatter and memory cleanup metadata, prints `HEARTBEAT_OK` when clean, and reports only when the agent needs to review stale context or memory files. Use `mex watch --interval` to run heartbeat repeatedly in a persistent-agent workspace.
+
+## Configuration
+
+Optional settings live in `.mex/config.json`. Missing values fall back to defaults.
+
+```json
+{
+  "staleness": {
+    "warnDays": 30,
+    "errorDays": 90,
+    "warnCommits": 50,
+    "errorCommits": 200
+  },
+  "heartbeat": {
+    "staleDays": 7,
+    "memoryCleanupDays": 7,
+    "dailyMemoryRetentionDays": 14
+  },
+  "watch": {
+    "intervalMinutes": 30
+  }
+}
+```
 
 ## File Structure
 
@@ -205,6 +246,9 @@ your-project/
 ├── .mex/
 │   ├── ROUTER.md          ← routing table, session bootstrap
 │   ├── AGENTS.md          ← always-loaded anchor (~150 tokens)
+│   ├── HEARTBEAT.md       ← agent-memory heartbeat contract (agent-memory mode)
+│   ├── events/
+│   │   └── decisions.jsonl   # append-only notes/decisions from mex log
 │   ├── context/
 │   │   ├── architecture.md   # how components connect
 │   │   ├── stack.md           # technology choices and reasoning

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,274 @@
+# mex v0.3
+
+This release turns mex from a drift-aware scaffold CLI into a small operational memory layer for agents.
+
+The original goal of mex is still the same: keep agent context useful, navigable, and honest without dumping an entire project into the prompt. v0.3 keeps the stable v0.2 scaffold architecture, then adds the pieces that make mex work better for persistent agents, homelabs, OpenClaw-style operational workspaces, and long-running project memory.
+
+npm package: `promexeus@0.3.5`
+
+## Highlights
+
+- **Agent memory mode** for persistent agents and operational workspaces.
+- **Heartbeat checks** for scheduled agent health review.
+- **Event log and timeline** for decisions, risks, todos, and notes.
+- **Interactive TUI dashboard** included in the release.
+- **Better check/doctor output** for humans and scripts.
+- **Tunable config** for staleness, heartbeat, and watch intervals.
+- **Shell completions** for bash, zsh, and fish.
+
+## Agent Memory Layer
+
+v0.3 adds a first-class agent-memory setup mode:
+
+```bash
+npx promexeus setup --mode agent-memory
+```
+
+This is for projects where the "codebase" is not necessarily the main thing being remembered. Examples:
+
+- a persistent local agent
+- a homelab or server environment
+- OpenClaw-style operational workspaces
+- Kubernetes/Docker/Ansible/Terraform runbooks
+- long-running personal or team automation contexts
+
+Agent-memory mode creates templates that treat mex as structured memory:
+
+- `AGENTS.md` gives the agent a compact operating contract.
+- `ROUTER.md` routes tasks to the right memory files.
+- `HEARTBEAT.md` defines scheduled health checks.
+- `context/` stores durable current-state memory.
+- `patterns/` stores repeatable runbooks.
+- `.mex/events/decisions.jsonl` stores append-only decisions and notes.
+
+The GROW loop was updated for this use case:
+
+- **Ground** what changed.
+- **Record** the current truth in scaffold files.
+- **Orient** by adding or refining patterns.
+- **Write** `last_updated` and log rationale with `mex log` when it matters.
+
+## Heartbeat and Scheduled Checks
+
+New command:
+
+```bash
+mex heartbeat
+```
+
+Heartbeat is intentionally lighter than `mex check`. It is meant for persistent-agent setups where an agent may be woken up on a schedule and asked, "Is anything stale or due for review?"
+
+It checks:
+
+- optional `last_updated` frontmatter in scaffold files
+- stale context files
+- memory cleanup due dates
+- old daily memory files in agent-memory workspaces
+
+Clean output:
+
+```bash
+HEARTBEAT_OK
+```
+
+JSON output:
+
+```bash
+mex heartbeat --json
+```
+
+Scheduled foreground loop:
+
+```bash
+mex watch --interval
+mex watch --interval 15
+```
+
+This runs heartbeat repeatedly instead of installing a post-commit hook. The existing `mex watch` hook behavior still works.
+
+## Event Log and Timeline
+
+v0.3 adds a tiny append-only event layer:
+
+```bash
+mex log "rotated API keys after provider incident"
+mex log --type decision "keep OpenClaw ingress behind Cloudflare tunnel"
+mex log --type risk --file .mex/context/setup.md "backup restore path is not tested yet"
+```
+
+Events are stored at:
+
+```text
+.mex/events/decisions.jsonl
+```
+
+Read them back with:
+
+```bash
+mex timeline
+mex timeline --limit 20
+mex timeline --json
+```
+
+This gives agents a lightweight way to preserve rationale without changing the scaffold schema or requiring a full event-sourcing architecture.
+
+## TUI Dashboard
+
+Bare `mex` now opens an interactive terminal dashboard:
+
+```bash
+mex
+mex tui
+```
+
+The TUI shows:
+
+- current scaffold path
+- drift score
+- error/warning counts
+- files checked
+- heartbeat status
+- stale file count
+- recent event activity
+- latest timeline signal
+
+Available actions:
+
+- refresh dashboard
+- run check summary
+- run heartbeat
+- run doctor summary
+- view timeline
+- log event
+- exit
+
+This is additive. All existing CLI commands still work the same and remain script-friendly.
+
+## Better Health and Check Output
+
+`mex check` now has clearer grouped output and script support:
+
+```bash
+mex check
+mex check --quiet
+mex check --json
+```
+
+Issues are easier to scan by severity, and remediation hints are clearer.
+
+New doctor command:
+
+```bash
+mex doctor
+```
+
+`doctor` gives a friendly health summary across drift, heartbeat, config, and events.
+
+## Tunable Config
+
+Optional settings live in `.mex/config.json`.
+
+Example:
+
+```json
+{
+  "staleness": {
+    "warnDays": 30,
+    "errorDays": 90,
+    "warnCommits": 50,
+    "errorCommits": 200
+  },
+  "watch": {
+    "intervalMinutes": 30
+  },
+  "heartbeat": {
+    "staleDays": 7,
+    "memoryCleanupDays": 7,
+    "dailyMemoryRetentionDays": 14
+  }
+}
+```
+
+Missing values use defaults, so existing scaffolds do not need a migration.
+
+## Shell Completions
+
+Generate completions with:
+
+```bash
+mex completion bash
+mex completion zsh
+mex completion fish
+```
+
+## OpenClaw / Persistent Agent Use Case
+
+The release is heavily informed by OpenClaw-style usage: an agent operating over a homelab-like environment with Kubernetes, Docker, Ansible, Terraform, networking, monitoring, and long-lived operational state.
+
+For that workflow, mex v0.3 is useful because it separates three kinds of memory:
+
+- **State memory:** current truth in `ROUTER.md` and `context/`.
+- **Procedural memory:** repeatable runbooks in `patterns/`.
+- **Event memory:** decisions, risks, and notes in `.mex/events/decisions.jsonl`.
+
+A persistent agent can now:
+
+1. Start by reading `ROUTER.md`.
+2. Load only the memory files relevant to the task.
+3. Run the right playbook from `patterns/`.
+4. Log decisions with `mex log`.
+5. Run `mex heartbeat` on a schedule to catch stale memory.
+
+This expands mex beyond code repositories while keeping the original scaffold model intact.
+
+## Compatibility
+
+No scaffold migration is required.
+
+v0.3 deliberately avoids the shelved routing/schema architecture work. Existing v0.2 scaffolds continue to work, and new features are additive:
+
+- `last_updated` is optional.
+- `.mex/config.json` is optional.
+- `.mex/events/` is created when events are logged.
+- TUI is additive and does not replace CLI commands.
+
+## Not Included
+
+The following remain intentionally deferred:
+
+- context routing command
+- full schema migration with ids/requires fields
+- federation / hierarchical scaffolds
+- bidirectional state-event references
+- dynamic domain nodes via Tree-sitter
+
+Those need a bigger architecture story and are not part of this stable v0.3 release.
+
+## Upgrade
+
+Install or update:
+
+```bash
+npm install -g promexeus@latest
+```
+
+Or use directly:
+
+```bash
+npx promexeus@latest setup
+```
+
+For an existing project, no scaffold reset is needed. Update the package, then run:
+
+```bash
+mex doctor
+mex check
+```
+
+For an agent-memory workspace:
+
+```bash
+npx promexeus@latest setup --mode agent-memory
+mex heartbeat
+```
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,19 @@
 {
   "name": "promexeus",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "promexeus",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",
         "commander": "^13.1.0",
         "glob": "^11.0.1",
+        "ink": "^7.0.3",
+        "react": "^19.2.6",
         "remark-frontmatter": "^5.0.0",
         "remark-parse": "^11.0.0",
         "simple-git": "^3.27.0",
@@ -24,12 +26,27 @@
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
+        "@types/react": "^19.2.14",
+        "ink-testing-library": "^4.0.0",
         "tsup": "^8.4.0",
         "typescript": "^5.7.0",
         "vitest": "^3.0.0"
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@alcalzone/ansi-tokenize": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.3.0.tgz",
+      "integrity": "sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -946,6 +963,16 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -1080,6 +1107,45 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -1095,6 +1161,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/auto-bind": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz",
+      "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/bail": {
@@ -1219,6 +1297,61 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/cli-boxes": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-4.0.1.tgz",
+      "integrity": "sha512-5IOn+jcCEHEraYolBPs/sT4BxYCe2nHg374OPiItB1O96KZFseS2gthU4twyYzeDcFew4DaUM/xwc5BQf08JJw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.20 <19 || >=20.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-6.0.0.tgz",
+      "integrity": "sha512-3+YKIUFsohD9MIoOFPFBldjAlnfCmCDcqe6aYGFqlDTRKg80p4wg35L+j83QQ63iOlKRccEkbn8IuM++HsgEjA==",
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^9.0.0",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/code-excerpt": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz",
+      "integrity": "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==",
+      "license": "MIT",
+      "dependencies": {
+        "convert-to-spaces": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/commander": {
       "version": "13.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
@@ -1245,6 +1378,15 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
+    "node_modules/convert-to-spaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
+      "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1258,6 +1400,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1321,12 +1470,34 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.27.4",
@@ -1490,6 +1661,18 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/glob": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
@@ -1512,6 +1695,121 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ink": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/ink/-/ink-7.0.3.tgz",
+      "integrity": "sha512-5kxHkIj9+RuqCU3zyvP4qvYWNOSHP2TW/SHayHGHOmk87KwfVcZwvJGemi9ch+ci2gXUqerK/Eh2DGEDt5q45g==",
+      "license": "MIT",
+      "dependencies": {
+        "@alcalzone/ansi-tokenize": "^0.3.0",
+        "ansi-escapes": "^7.3.0",
+        "ansi-styles": "^6.2.3",
+        "auto-bind": "^5.0.1",
+        "chalk": "^5.6.2",
+        "cli-boxes": "^4.0.1",
+        "cli-cursor": "^4.0.0",
+        "cli-truncate": "^6.0.0",
+        "code-excerpt": "^4.0.0",
+        "es-toolkit": "^1.45.1",
+        "indent-string": "^5.0.0",
+        "is-in-ci": "^2.0.0",
+        "patch-console": "^2.0.0",
+        "react-reconciler": "^0.33.0",
+        "scheduler": "^0.27.0",
+        "signal-exit": "^3.0.7",
+        "slice-ansi": "^9.0.0",
+        "stack-utils": "^2.0.6",
+        "string-width": "^8.2.0",
+        "terminal-size": "^4.0.1",
+        "type-fest": "^5.5.0",
+        "widest-line": "^6.0.0",
+        "wrap-ansi": "^10.0.0",
+        "ws": "^8.20.0",
+        "yoga-layout": "~3.2.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "@types/react": ">=19.2.0",
+        "react": ">=19.2.0",
+        "react-devtools-core": ">=6.1.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react-devtools-core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ink-testing-library": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ink-testing-library/-/ink-testing-library-4.0.0.tgz",
+      "integrity": "sha512-yF92kj3pmBvk7oKbSq5vEALO//o7Z9Ck/OaLNlkzXNeYdwfpxMQkSowGTFUCS5MSu9bWfSZMewGpp7bFc66D7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ink/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-in-ci": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-2.0.0.tgz",
+      "integrity": "sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w==",
+      "license": "MIT",
+      "bin": {
+        "is-in-ci": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-plain-obj": {
@@ -2178,6 +2476,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
@@ -2262,11 +2569,35 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/patch-console": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
+      "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -2424,6 +2755,30 @@
         }
       }
     },
+    "node_modules/react": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.33.0.tgz",
+      "integrity": "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.0"
+      }
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -2480,6 +2835,28 @@
         "node": ">=8"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
     "node_modules/rollup": {
       "version": "4.59.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.1.tgz",
@@ -2524,6 +2901,12 @@
         "@rollup/rollup-win32-x64-msvc": "4.59.1",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -2580,6 +2963,22 @@
         "url": "https://github.com/steveukx/git-js?sponsor=1"
       }
     },
+    "node_modules/slice-ansi": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-9.0.0.tgz",
+      "integrity": "sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
@@ -2600,6 +2999,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -2613,6 +3033,37 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
     },
     "node_modules/strip-literal": {
       "version": "3.1.0",
@@ -2658,6 +3109,30 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/terminal-size": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/terminal-size/-/terminal-size-4.0.1.tgz",
+      "integrity": "sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/thenify": {
@@ -2822,6 +3297,21 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
+      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typescript": {
@@ -3157,6 +3647,59 @@
         "node": ">=8"
       }
     },
+    "node_modules/widest-line": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-6.0.0.tgz",
+      "integrity": "sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz",
+      "integrity": "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "string-width": "^8.2.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/yaml": {
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
@@ -3171,6 +3714,12 @@
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
       }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
     },
     "node_modules/zwitch": {
       "version": "2.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "promexeus",
-  "version": "0.3.3",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "promexeus",
-      "version": "0.3.3",
+      "version": "0.3.5",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "chalk": "^5.4.1",
     "commander": "^13.1.0",
     "glob": "^11.0.1",
+    "ink": "^7.0.3",
+    "react": "^19.2.6",
     "remark-frontmatter": "^5.0.0",
     "remark-parse": "^11.0.0",
     "simple-git": "^3.27.0",
@@ -53,6 +55,8 @@
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
+    "@types/react": "^19.2.14",
+    "ink-testing-library": "^4.0.0",
     "tsup": "^8.4.0",
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promexeus",
-  "version": "0.3.3",
+  "version": "0.3.5",
   "description": "CLI engine for mex scaffold — drift detection, pre-analysis, and targeted sync",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,6 +30,7 @@ program
   .name("mex")
   .description("CLI engine for mex scaffold — drift detection, pre-analysis, and targeted sync")
   .version("0.3.5")
+  .showHelpAfterError()
   .action(async () => {
     await runTuiCommand();
   });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,7 +29,7 @@ async function runTuiCommand(): Promise<void> {
 program
   .name("mex")
   .description("CLI engine for mex scaffold — drift detection, pre-analysis, and targeted sync")
-  .version("0.3.3")
+  .version("0.3.5")
   .action(async () => {
     await runTuiCommand();
   });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,10 +21,25 @@ function parsePositiveIntArg(raw: string): number {
 
 const program = new Command();
 
+async function runTuiCommand(): Promise<void> {
+  const { launchTui } = await import("./tui.js");
+  launchTui();
+}
+
 program
   .name("mex")
   .description("CLI engine for mex scaffold — drift detection, pre-analysis, and targeted sync")
-  .version("0.3.3");
+  .version("0.3.3")
+  .action(async () => {
+    await runTuiCommand();
+  });
+
+program
+  .command("tui")
+  .description("Open the interactive mex dashboard")
+  .action(async () => {
+    await runTuiCommand();
+  });
 
 // ── Setup (npx entry point) ──
 program
@@ -273,6 +288,7 @@ program
     console.log("  mex timeline           Show recent event log entries");
     console.log("  mex heartbeat          Run lightweight agent-memory health checks");
     console.log("  mex doctor             Friendly scaffold health summary");
+    console.log("  mex tui                Open the interactive mex dashboard");
     console.log("  mex pattern add <name> Create a new pattern file");
     console.log("  mex watch              Install post-commit hook for auto drift score");
     console.log("  mex watch --interval   Run heartbeat every 30 minutes (or config value)");
@@ -287,7 +303,7 @@ program.parse();
 function buildCompletion(shell: string): string {
   const commands = [
     "setup", "check", "init", "sync", "pattern", "log", "timeline",
-    "heartbeat", "doctor", "watch", "commands", "completion",
+    "heartbeat", "doctor", "watch", "tui", "commands", "completion",
   ];
   if (shell === "bash") {
     return `_mex_completion() {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,22 +11,31 @@ function parseIntArg(raw: string): number {
   return n;
 }
 
+function parsePositiveIntArg(raw: string): number {
+  const n = parseIntArg(raw);
+  if (n <= 0) {
+    throw new InvalidArgumentError(`Expected a positive integer, got "${raw}".`);
+  }
+  return n;
+}
+
 const program = new Command();
 
 program
   .name("mex")
   .description("CLI engine for mex scaffold — drift detection, pre-analysis, and targeted sync")
-  .version("0.4.0");
+  .version("0.3.3");
 
 // ── Setup (npx entry point) ──
 program
   .command("setup")
   .description("First-time setup — create .mex/ scaffold and populate with AI")
+  .option("--mode <mode>", "Template mode: code-repo (default) or agent-memory", "code-repo")
   .option("--dry-run", "Show what would happen without making changes")
   .action(async (opts) => {
     try {
       const { runSetup } = await import("./setup/index.js");
-      await runSetup({ dryRun: opts.dryRun });
+      await runSetup({ dryRun: opts.dryRun, mode: opts.mode });
     } catch (err) {
       console.error((err as Error).message);
       process.exit(1);
@@ -109,6 +118,70 @@ program
     }
   });
 
+// ── Agent Memory Events ──
+program
+  .command("log <message>")
+  .description("Append a decision, note, risk, or todo to the mex event log")
+  .option("--type <type>", "Event type: decision, note, risk, todo", "note")
+  .option("--file <path>", "Related file path (repeatable)", (value, prev: string[]) => [...prev, value], [])
+  .action(async (message, opts) => {
+    try {
+      const config = findConfig();
+      const { runLog } = await import("./events.js");
+      await runLog(config, message, { kind: opts.type, files: opts.file });
+    } catch (err) {
+      console.error((err as Error).message);
+      process.exit(1);
+    }
+  });
+
+program
+  .command("timeline")
+  .description("Show recent mex event log entries")
+  .option("--json", "Output events as JSON")
+  .option("--since <date>", "Filter from YYYY-MM-DD or relative Nd, e.g. 30d")
+  .option("--type <type>", "Filter by event type")
+  .option("--limit <n>", "Maximum number of entries", parsePositiveIntArg)
+  .action(async (opts) => {
+    try {
+      const config = findConfig();
+      const { runTimeline } = await import("./events.js");
+      await runTimeline(config, opts);
+    } catch (err) {
+      console.error((err as Error).message);
+      process.exit(1);
+    }
+  });
+
+program
+  .command("heartbeat")
+  .description("Run lightweight agent-memory health checks once")
+  .option("--json", "Output heartbeat report as JSON")
+  .action(async (opts) => {
+    try {
+      const config = findConfig();
+      const { runHeartbeat } = await import("./heartbeat.js");
+      await runHeartbeat(config, { json: opts.json });
+    } catch (err) {
+      console.error((err as Error).message);
+      process.exit(1);
+    }
+  });
+
+program
+  .command("doctor")
+  .description("Run a friendly scaffold health diagnostic")
+  .action(async () => {
+    try {
+      const config = findConfig();
+      const { runDoctor } = await import("./doctor.js");
+      await runDoctor(config);
+    } catch (err) {
+      console.error((err as Error).message);
+      process.exit(1);
+    }
+  });
+
 // ── Layer 3: Targeted Sync ──
 program
   .command("sync")
@@ -148,13 +221,31 @@ patternCmd
 // ── Git Hook ──
 program
   .command("watch")
-  .description("Install/uninstall post-commit hook for automatic drift checking")
+  .description("Install/uninstall post-commit hook, or run heartbeat on an interval")
   .option("--uninstall", "Remove the post-commit hook")
+  .option("--interval [minutes]", "Run mex heartbeat repeatedly instead of installing a hook", (v) => v === undefined ? true : parsePositiveIntArg(v))
   .action(async (opts) => {
     try {
       const config = findConfig();
       const { manageHook } = await import("./watch.js");
-      await manageHook(config, { uninstall: opts.uninstall });
+      const intervalMinutes = opts.interval === true
+        ? config.watch?.intervalMinutes ?? 30
+        : typeof opts.interval === "number"
+          ? opts.interval
+          : undefined;
+      await manageHook(config, { uninstall: opts.uninstall, intervalMinutes });
+    } catch (err) {
+      console.error((err as Error).message);
+      process.exit(1);
+    }
+  });
+
+program
+  .command("completion <shell>")
+  .description("Print shell completion script for bash, zsh, or fish")
+  .action((shell) => {
+    try {
+      console.log(buildCompletion(shell));
     } catch (err) {
       console.error((err as Error).message);
       process.exit(1);
@@ -178,8 +269,13 @@ program
     console.log("  mex sync --warnings    Include warning-only files in sync");
     console.log("  mex init               Pre-scan codebase, build brief for AI");
     console.log("  mex init --json        Scanner brief as JSON");
+    console.log("  mex log <message>      Append a note/decision/risk/todo to the event log");
+    console.log("  mex timeline           Show recent event log entries");
+    console.log("  mex heartbeat          Run lightweight agent-memory health checks");
+    console.log("  mex doctor             Friendly scaffold health summary");
     console.log("  mex pattern add <name> Create a new pattern file");
     console.log("  mex watch              Install post-commit hook for auto drift score");
+    console.log("  mex watch --interval   Run heartbeat every 30 minutes (or config value)");
     console.log("  mex watch --uninstall  Remove the post-commit hook");
     console.log();
     console.log(chalk.dim("Not installed globally? Replace 'mex' with 'npx promexeus'."));
@@ -187,3 +283,24 @@ program
   });
 
 program.parse();
+
+function buildCompletion(shell: string): string {
+  const commands = [
+    "setup", "check", "init", "sync", "pattern", "log", "timeline",
+    "heartbeat", "doctor", "watch", "commands", "completion",
+  ];
+  if (shell === "bash") {
+    return `_mex_completion() {
+  COMPREPLY=($(compgen -W "${commands.join(" ")}" -- "\${COMP_WORDS[COMP_CWORD]}"))
+}
+complete -F _mex_completion mex`;
+  }
+  if (shell === "zsh") {
+    return `#compdef mex
+_arguments '1:command:(${commands.join(" ")})'`;
+  }
+  if (shell === "fish") {
+    return commands.map((cmd) => `complete -c mex -f -a ${cmd}`).join("\n");
+  }
+  throw new Error(`Unknown shell "${shell}". Use bash, zsh, or fish.`);
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -36,10 +36,11 @@ export function findConfig(startDir?: string): MexConfig {
     );
   }
 
-  const aiTools = loadAiTools(scaffoldRoot);
-  const stalenessThresholds = loadStalenessThresholds(scaffoldRoot);
-  const watch = loadWatchConfig(scaffoldRoot);
-  const heartbeat = loadHeartbeatConfig(scaffoldRoot);
+  const persistedConfig = loadPersistedConfig(scaffoldRoot);
+  const aiTools = loadAiTools(persistedConfig);
+  const stalenessThresholds = loadStalenessThresholds(scaffoldRoot, persistedConfig);
+  const watch = loadWatchConfig(persistedConfig);
+  const heartbeat = loadHeartbeatConfig(persistedConfig);
   return { projectRoot, scaffoldRoot, aiTools, stalenessThresholds, watch, heartbeat };
 }
 
@@ -69,22 +70,13 @@ interface MexPersistedConfig {
 
 const VALID_AI_TOOLS = new Set<string>(["claude", "cursor", "windsurf", "copilot", "opencode", "codex"]);
 
-function loadAiTools(scaffoldRoot: string): AiTool[] {
-  const configPath = resolve(scaffoldRoot, CONFIG_FILE);
-  if (!existsSync(configPath)) return [];
-  try {
-    const raw = JSON.parse(readFileSync(configPath, "utf-8"));
-    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return [];
-    const arr = (raw as MexPersistedConfig).aiTools;
-    if (!Array.isArray(arr)) return [];
-    return arr.filter((v): v is AiTool => typeof v === "string" && VALID_AI_TOOLS.has(v));
-  } catch {
-    return [];
-  }
+function loadAiTools(raw: MexPersistedConfig | null): AiTool[] {
+  const arr = raw?.aiTools;
+  if (!Array.isArray(arr)) return [];
+  return arr.filter((v): v is AiTool => typeof v === "string" && VALID_AI_TOOLS.has(v));
 }
 
-function loadStalenessThresholds(scaffoldRoot: string): StalenessThresholds | undefined {
-  const raw = loadPersistedConfig(scaffoldRoot);
+function loadStalenessThresholds(scaffoldRoot: string, raw: MexPersistedConfig | null): StalenessThresholds | undefined {
   const configPath = resolve(scaffoldRoot, CONFIG_FILE);
   if (!raw) return undefined;
   try {
@@ -134,8 +126,7 @@ function loadStalenessThresholds(scaffoldRoot: string): StalenessThresholds | un
   }
 }
 
-function loadWatchConfig(scaffoldRoot: string): WatchConfig | undefined {
-  const raw = loadPersistedConfig(scaffoldRoot);
+function loadWatchConfig(raw: MexPersistedConfig | null): WatchConfig | undefined {
   if (!raw || typeof raw.watch !== "object" || raw.watch === null || Array.isArray(raw.watch)) {
     return undefined;
   }
@@ -144,8 +135,7 @@ function loadWatchConfig(scaffoldRoot: string): WatchConfig | undefined {
   return intervalMinutes === undefined ? undefined : { intervalMinutes };
 }
 
-function loadHeartbeatConfig(scaffoldRoot: string): HeartbeatConfig | undefined {
-  const raw = loadPersistedConfig(scaffoldRoot);
+function loadHeartbeatConfig(raw: MexPersistedConfig | null): HeartbeatConfig | undefined {
   if (!raw || typeof raw.heartbeat !== "object" || raw.heartbeat === null || Array.isArray(raw.heartbeat)) {
     return undefined;
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { resolve, dirname } from "node:path";
-import type { MexConfig, AiTool, StalenessThresholds } from "./types.js";
+import type { MexConfig, AiTool, StalenessThresholds, WatchConfig, HeartbeatConfig } from "./types.js";
 import { DEFAULT_STALENESS_THRESHOLDS } from "./drift/checkers/staleness.js";
 
 /**
@@ -38,7 +38,9 @@ export function findConfig(startDir?: string): MexConfig {
 
   const aiTools = loadAiTools(scaffoldRoot);
   const stalenessThresholds = loadStalenessThresholds(scaffoldRoot);
-  return { projectRoot, scaffoldRoot, aiTools, stalenessThresholds };
+  const watch = loadWatchConfig(scaffoldRoot);
+  const heartbeat = loadHeartbeatConfig(scaffoldRoot);
+  return { projectRoot, scaffoldRoot, aiTools, stalenessThresholds, watch, heartbeat };
 }
 
 function findProjectRoot(dir: string): string | null {
@@ -60,6 +62,8 @@ const CONFIG_FILE = "config.json";
 interface MexPersistedConfig {
   aiTools?: unknown;
   staleness?: unknown;
+  watch?: unknown;
+  heartbeat?: unknown;
   [key: string]: unknown;
 }
 
@@ -80,12 +84,11 @@ function loadAiTools(scaffoldRoot: string): AiTool[] {
 }
 
 function loadStalenessThresholds(scaffoldRoot: string): StalenessThresholds | undefined {
+  const raw = loadPersistedConfig(scaffoldRoot);
   const configPath = resolve(scaffoldRoot, CONFIG_FILE);
-  if (!existsSync(configPath)) return undefined;
+  if (!raw) return undefined;
   try {
-    const raw = JSON.parse(readFileSync(configPath, "utf-8"));
-    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return undefined;
-    const staleness = (raw as MexPersistedConfig).staleness;
+    const staleness = raw.staleness;
     if (typeof staleness !== "object" || staleness === null || Array.isArray(staleness)) return undefined;
     const s = staleness as Record<string, unknown>;
 
@@ -128,6 +131,49 @@ function loadStalenessThresholds(scaffoldRoot: string): StalenessThresholds | un
     return resolved;
   } catch {
     return undefined;
+  }
+}
+
+function loadWatchConfig(scaffoldRoot: string): WatchConfig | undefined {
+  const raw = loadPersistedConfig(scaffoldRoot);
+  if (!raw || typeof raw.watch !== "object" || raw.watch === null || Array.isArray(raw.watch)) {
+    return undefined;
+  }
+  const w = raw.watch as Record<string, unknown>;
+  const intervalMinutes = readPositiveNumber(w.intervalMinutes);
+  return intervalMinutes === undefined ? undefined : { intervalMinutes };
+}
+
+function loadHeartbeatConfig(scaffoldRoot: string): HeartbeatConfig | undefined {
+  const raw = loadPersistedConfig(scaffoldRoot);
+  if (!raw || typeof raw.heartbeat !== "object" || raw.heartbeat === null || Array.isArray(raw.heartbeat)) {
+    return undefined;
+  }
+  const h = raw.heartbeat as Record<string, unknown>;
+  const out: HeartbeatConfig = {};
+  const staleDays = readPositiveNumber(h.staleDays);
+  const memoryCleanupDays = readPositiveNumber(h.memoryCleanupDays);
+  const dailyMemoryRetentionDays = readPositiveNumber(h.dailyMemoryRetentionDays);
+  if (staleDays !== undefined) out.staleDays = staleDays;
+  if (memoryCleanupDays !== undefined) out.memoryCleanupDays = memoryCleanupDays;
+  if (dailyMemoryRetentionDays !== undefined) out.dailyMemoryRetentionDays = dailyMemoryRetentionDays;
+  return Object.keys(out).length ? out : undefined;
+}
+
+function readPositiveNumber(v: unknown): number | undefined {
+  if (typeof v === "number" && Number.isFinite(v) && v > 0) return v;
+  return undefined;
+}
+
+function loadPersistedConfig(scaffoldRoot: string): MexPersistedConfig | null {
+  const configPath = resolve(scaffoldRoot, CONFIG_FILE);
+  if (!existsSync(configPath)) return null;
+  try {
+    const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
+    return raw as MexPersistedConfig;
+  } catch {
+    return null;
   }
 }
 

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -1,3 +1,5 @@
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
 import chalk from "chalk";
 import type { MexConfig } from "./types.js";
 import { runDriftCheck } from "./drift/index.js";
@@ -18,7 +20,8 @@ export async function runDoctor(config: MexConfig): Promise<void> {
   printLine("Drift", report.score >= 80 && errors === 0, `${report.score}/100 (${errors} errors, ${warnings} warnings)`);
   printLine("Heartbeat", heartbeat.ok, heartbeat.ok ? "HEARTBEAT_OK" : `${heartbeat.staleFiles.length} stale files, ${heartbeat.oldDailyMemoryFiles.length} old memory files`);
   printLine("Events", true, `${events.length} logged event${events.length === 1 ? "" : "s"}`);
-  printLine("Config", true, ".mex/config.json loaded with defaults for missing values");
+  const hasConfig = existsSync(resolve(config.scaffoldRoot, "config.json"));
+  printLine("Config", true, hasConfig ? ".mex/config.json loaded with defaults for missing values" : "using defaults; no .mex/config.json found");
 
   if (errors || warnings || !heartbeat.ok) {
     console.log();

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -1,0 +1,36 @@
+import chalk from "chalk";
+import type { MexConfig } from "./types.js";
+import { runDriftCheck } from "./drift/index.js";
+import { checkHeartbeat } from "./heartbeat.js";
+import { readEvents } from "./events.js";
+
+export async function runDoctor(config: MexConfig): Promise<void> {
+  console.log(chalk.bold("mex doctor"));
+  console.log(chalk.dim(`Scaffold: ${config.scaffoldRoot}`));
+  console.log();
+
+  const report = await runDriftCheck(config);
+  const errors = report.issues.filter((i) => i.severity === "error").length;
+  const warnings = report.issues.filter((i) => i.severity === "warning").length;
+  const heartbeat = checkHeartbeat(config);
+  const events = readEvents(config);
+
+  printLine("Drift", report.score >= 80 && errors === 0, `${report.score}/100 (${errors} errors, ${warnings} warnings)`);
+  printLine("Heartbeat", heartbeat.ok, heartbeat.ok ? "HEARTBEAT_OK" : `${heartbeat.staleFiles.length} stale files, ${heartbeat.oldDailyMemoryFiles.length} old memory files`);
+  printLine("Events", true, `${events.length} logged event${events.length === 1 ? "" : "s"}`);
+  printLine("Config", true, ".mex/config.json loaded with defaults for missing values");
+
+  if (errors || warnings || !heartbeat.ok) {
+    console.log();
+    console.log(chalk.bold("Next steps"));
+    if (errors || warnings) console.log("  Run `mex check` for drift details, then `mex sync` for targeted repair prompts.");
+    if (!heartbeat.ok) console.log("  Run `mex heartbeat` to see stale context or memory cleanup details.");
+  }
+
+  if (errors) process.exitCode = 1;
+}
+
+function printLine(label: string, ok: boolean, detail: string): void {
+  const icon = ok ? chalk.green("✓") : chalk.yellow("!");
+  console.log(`${icon} ${chalk.bold(label)} ${chalk.dim(detail)}`);
+}

--- a/src/drift/checkers/staleness.ts
+++ b/src/drift/checkers/staleness.ts
@@ -69,7 +69,8 @@ export async function checkStaleness(
   filePath: string,
   source: string,
   cwd: string,
-  thresholds: StalenessThresholds = DEFAULT_STALENESS_THRESHOLDS
+  thresholds: StalenessThresholds = DEFAULT_STALENESS_THRESHOLDS,
+  opts: { lastUpdated?: string } = {}
 ): Promise<DriftIssue[]> {
   const { warnDays, errorDays, warnCommits, errorCommits } = thresholds;
 
@@ -84,6 +85,18 @@ export async function checkStaleness(
   if (commits !== null) {
     const s = commitsSignal(commits, warnCommits, errorCommits);
     if (s) signals.push(s);
+  }
+  const fieldDays = daysSinceFrontmatterDate(opts.lastUpdated);
+  if (fieldDays !== null) {
+    const s = daysSignal(fieldDays, warnDays, errorDays);
+    if (s) {
+      signals.push({
+        severity: s.severity,
+        message: `last_updated is ${fieldDays} days old (threshold: ${
+          s.severity === "error" ? errorDays : warnDays
+        }d)`,
+      });
+    }
   }
 
   if (signals.length === 0) return [];
@@ -103,4 +116,15 @@ export async function checkStaleness(
       message,
     },
   ];
+}
+
+export function daysSinceFrontmatterDate(value: string | undefined, now = new Date()): number | null {
+  if (!value || value.includes("[") || value.includes("]")) return null;
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return null;
+  const date = new Date(`${value}T00:00:00.000Z`);
+  if (Number.isNaN(date.getTime())) return null;
+  const todayUtc = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+  const dateUtc = Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+  const days = Math.floor((todayUtc - dateUtc) / 86_400_000);
+  return days < 0 ? null : days;
 }

--- a/src/drift/index.ts
+++ b/src/drift/index.ts
@@ -50,6 +50,7 @@ export async function runDriftCheck(
       source,
       projectRoot,
       config.stalenessThresholds,
+      { lastUpdated: typeof frontmatter?.last_updated === "string" ? frontmatter.last_updated : undefined },
     );
     allIssues.push(...stalenessIssues);
 
@@ -123,6 +124,7 @@ function findScaffoldFiles(
     const matches = globSync(pattern, {
       cwd: scaffoldRoot,
       absolute: true,
+      follow: true,
       ignore: ["node_modules/**"],
     });
     files.push(...matches);

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,0 +1,129 @@
+import { existsSync, mkdirSync, appendFileSync, readFileSync } from "node:fs";
+import { dirname, resolve, relative } from "node:path";
+import chalk from "chalk";
+import type { MexConfig } from "./types.js";
+
+export type EventKind = "decision" | "note" | "risk" | "todo";
+
+export interface EventEntry {
+  timestamp: string;
+  kind: EventKind;
+  message: string;
+  files: string[];
+  cwd: string;
+}
+
+export interface LogOpts {
+  kind?: string;
+  files?: string[];
+}
+
+export interface TimelineOpts {
+  json?: boolean;
+  since?: string;
+  kind?: string;
+  limit?: number;
+}
+
+const VALID_KINDS = new Set<EventKind>(["decision", "note", "risk", "todo"]);
+const EVENT_FILE = "events/decisions.jsonl";
+
+export function eventLogPath(config: MexConfig): string {
+  return resolve(config.scaffoldRoot, EVENT_FILE);
+}
+
+export async function runLog(config: MexConfig, message: string, opts: LogOpts = {}): Promise<void> {
+  const kind = normalizeKind(opts.kind);
+  const files = (opts.files ?? []).map((f) => relative(config.projectRoot, resolve(config.projectRoot, f)));
+  const entry: EventEntry = {
+    timestamp: new Date().toISOString(),
+    kind,
+    message,
+    files,
+    cwd: relative(config.projectRoot, process.cwd()) || ".",
+  };
+  const file = eventLogPath(config);
+  mkdirSync(dirname(file), { recursive: true });
+  appendFileSync(file, JSON.stringify(entry) + "\n");
+  console.log(chalk.green(`Logged ${kind}: ${message}`));
+}
+
+export async function runTimeline(config: MexConfig, opts: TimelineOpts = {}): Promise<void> {
+  const entries = readEvents(config);
+  const since = parseSince(opts.since);
+  const kind = opts.kind ? normalizeKind(opts.kind) : null;
+  let filtered = entries.filter((e) => {
+    if (kind && e.kind !== kind) return false;
+    if (since && new Date(e.timestamp) < since) return false;
+    return true;
+  });
+  filtered = filtered.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+  if (opts.limit && opts.limit > 0) filtered = filtered.slice(0, opts.limit);
+
+  if (opts.json) {
+    console.log(JSON.stringify({ events: filtered }, null, 2));
+    return;
+  }
+
+  if (filtered.length === 0) {
+    console.log(chalk.dim("No events found."));
+    return;
+  }
+
+  for (const e of filtered) {
+    const files = e.files.length ? chalk.dim(` (${e.files.join(", ")})`) : "";
+    console.log(`${chalk.bold(e.timestamp.slice(0, 10))} ${chalk.cyan(e.kind)} ${e.message}${files}`);
+  }
+}
+
+export function readEvents(config: MexConfig): EventEntry[] {
+  const file = eventLogPath(config);
+  if (!existsSync(file)) return [];
+  const lines = readFileSync(file, "utf-8").split("\n").filter(Boolean);
+  const entries: EventEntry[] = [];
+  for (const line of lines) {
+    try {
+      const raw = JSON.parse(line);
+      if (
+        typeof raw.timestamp === "string" &&
+        VALID_KINDS.has(raw.kind) &&
+        typeof raw.message === "string" &&
+        Array.isArray(raw.files)
+      ) {
+        entries.push({
+          timestamp: raw.timestamp,
+          kind: raw.kind,
+          message: raw.message,
+          files: raw.files.filter((f: unknown): f is string => typeof f === "string"),
+          cwd: typeof raw.cwd === "string" ? raw.cwd : ".",
+        });
+      }
+    } catch {
+      // Ignore malformed historical lines; timeline should remain usable.
+    }
+  }
+  return entries;
+}
+
+function normalizeKind(raw: string | undefined): EventKind {
+  const kind = (raw ?? "note").toLowerCase();
+  if (!VALID_KINDS.has(kind as EventKind)) {
+    throw new Error(`Unknown event type "${raw}". Use decision, note, risk, or todo.`);
+  }
+  return kind as EventKind;
+}
+
+function parseSince(raw: string | undefined): Date | null {
+  if (!raw) return null;
+  const days = raw.match(/^(\d+)d$/);
+  if (days) {
+    const d = new Date();
+    d.setUTCDate(d.getUTCDate() - Number(days[1]));
+    return d;
+  }
+  const parsed = new Date(`${raw}T00:00:00.000Z`);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`Invalid --since value "${raw}". Use YYYY-MM-DD or Nd, e.g. 30d.`);
+  }
+  return parsed;
+}

--- a/src/events.ts
+++ b/src/events.ts
@@ -33,6 +33,11 @@ export function eventLogPath(config: MexConfig): string {
 }
 
 export async function runLog(config: MexConfig, message: string, opts: LogOpts = {}): Promise<void> {
+  const entry = appendEvent(config, message, opts);
+  console.log(chalk.green(`Logged ${entry.kind}: ${message}`));
+}
+
+export function appendEvent(config: MexConfig, message: string, opts: LogOpts = {}): EventEntry {
   const kind = normalizeKind(opts.kind);
   const files = (opts.files ?? []).map((f) => relative(config.projectRoot, resolve(config.projectRoot, f)));
   const entry: EventEntry = {
@@ -45,7 +50,7 @@ export async function runLog(config: MexConfig, message: string, opts: LogOpts =
   const file = eventLogPath(config);
   mkdirSync(dirname(file), { recursive: true });
   appendFileSync(file, JSON.stringify(entry) + "\n");
-  console.log(chalk.green(`Logged ${kind}: ${message}`));
+  return entry;
 }
 
 export async function runTimeline(config: MexConfig, opts: TimelineOpts = {}): Promise<void> {

--- a/src/heartbeat.ts
+++ b/src/heartbeat.ts
@@ -1,0 +1,136 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve, relative } from "node:path";
+import { globSync } from "glob";
+import chalk from "chalk";
+import { parseFrontmatter } from "./drift/frontmatter.js";
+import { daysSinceFrontmatterDate } from "./drift/checkers/staleness.js";
+import type { MexConfig } from "./types.js";
+
+export interface HeartbeatResult {
+  ok: boolean;
+  staleFiles: Array<{ file: string; days: number }>;
+  memoryCleanupDue: boolean;
+  oldDailyMemoryFiles: string[];
+}
+
+export interface HeartbeatOpts {
+  json?: boolean;
+}
+
+const DEFAULT_STALE_DAYS = 7;
+const DEFAULT_MEMORY_CLEANUP_DAYS = 7;
+const DEFAULT_DAILY_MEMORY_RETENTION_DAYS = 14;
+
+export async function runHeartbeat(config: MexConfig, opts: HeartbeatOpts = {}): Promise<HeartbeatResult> {
+  const result = checkHeartbeat(config);
+  if (opts.json) {
+    console.log(JSON.stringify(result, null, 2));
+    return result;
+  }
+  printHeartbeat(result, config);
+  return result;
+}
+
+export function checkHeartbeat(config: MexConfig, now = new Date()): HeartbeatResult {
+  const staleDays = config.heartbeat?.staleDays ?? DEFAULT_STALE_DAYS;
+  const memoryCleanupDays = config.heartbeat?.memoryCleanupDays ?? DEFAULT_MEMORY_CLEANUP_DAYS;
+  const dailyRetentionDays = config.heartbeat?.dailyMemoryRetentionDays ?? DEFAULT_DAILY_MEMORY_RETENTION_DAYS;
+
+  const staleFiles = scaffoldHeartbeatFiles(config.scaffoldRoot)
+    .map((file) => {
+      const fm = parseFrontmatter(file);
+      const days = daysSinceFrontmatterDate(
+        typeof fm?.last_updated === "string" ? fm.last_updated : undefined,
+        now,
+      );
+      return days !== null && days > staleDays
+        ? { file: relative(config.scaffoldRoot, file), days }
+        : null;
+    })
+    .filter((v): v is { file: string; days: number } => Boolean(v));
+
+  const memoryCleanupDue = isMemoryCleanupDue(config.projectRoot, memoryCleanupDays, now);
+  const oldDailyMemoryFiles = oldMemoryFiles(config.projectRoot, dailyRetentionDays, now);
+
+  return {
+    ok: staleFiles.length === 0 && !memoryCleanupDue && oldDailyMemoryFiles.length === 0,
+    staleFiles,
+    memoryCleanupDue,
+    oldDailyMemoryFiles,
+  };
+}
+
+function scaffoldHeartbeatFiles(scaffoldRoot: string): string[] {
+  const patterns = ["ROUTER.md", "AGENTS.md", "context/*.md", "patterns/*.md"];
+  return patterns.flatMap((pattern) =>
+    globSync(pattern, {
+      cwd: scaffoldRoot,
+      absolute: true,
+      follow: true,
+      nodir: true,
+    }),
+  );
+}
+
+function isMemoryCleanupDue(projectRoot: string, thresholdDays: number, now: Date): boolean {
+  const file = resolve(projectRoot, "memory/.last-cleanup.json");
+  if (!existsSync(file)) return false;
+  try {
+    const raw = JSON.parse(readFileSync(file, "utf-8"));
+    if (typeof raw.lastCleanup !== "string") return false;
+    const days = daysSinceIsoDate(raw.lastCleanup, now);
+    return days !== null && days > thresholdDays;
+  } catch {
+    return false;
+  }
+}
+
+function oldMemoryFiles(projectRoot: string, retentionDays: number, now: Date): string[] {
+  const memoryRoot = resolve(projectRoot, "memory");
+  if (!existsSync(memoryRoot)) return [];
+  return globSync("*.md", { cwd: memoryRoot, nodir: true })
+    .filter((file) => /^\d{4}-\d{2}-\d{2}\.md$/.test(file))
+    .filter((file) => {
+      const days = daysSinceFrontmatterDate(file.replace(/\.md$/, ""), now);
+      return days !== null && days > retentionDays;
+    })
+    .map((file) => `memory/${file}`);
+}
+
+function daysSinceIsoDate(value: string, now: Date): number | null {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return null;
+  const todayUtc = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+  const dateUtc = Date.UTC(parsed.getUTCFullYear(), parsed.getUTCMonth(), parsed.getUTCDate());
+  const days = Math.floor((todayUtc - dateUtc) / 86_400_000);
+  return days < 0 ? null : days;
+}
+
+function printHeartbeat(result: HeartbeatResult, config: MexConfig): void {
+  if (result.ok) {
+    console.log("HEARTBEAT_OK");
+    return;
+  }
+
+  console.log(chalk.bold("Heartbeat needs attention"));
+  if (result.staleFiles.length) {
+    console.log();
+    console.log(chalk.yellow("Stale scaffold files:"));
+    for (const f of result.staleFiles) {
+      console.log(`  ${f.file} — last_updated ${f.days} days ago`);
+    }
+    console.log(chalk.dim("  Review these files and run `mex sync` if they no longer match reality."));
+  }
+  if (result.memoryCleanupDue) {
+    console.log();
+    console.log(chalk.yellow("Memory cleanup is due."));
+    console.log(chalk.dim("  Review memory/YYYY-MM-DD.md files and promote useful details to MEMORY.md."));
+  }
+  if (result.oldDailyMemoryFiles.length) {
+    console.log();
+    console.log(chalk.yellow("Old daily memory files:"));
+    for (const file of result.oldDailyMemoryFiles) console.log(`  ${file}`);
+  }
+  console.log();
+  console.log(chalk.dim(`Scaffold: ${config.scaffoldRoot}`));
+}

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -30,14 +30,14 @@ export function reportConsole(report: DriftReport): void {
     for (const [file, issues] of Object.entries(files)) {
       console.log(chalk.bold.underline(file));
       for (const issue of issues) {
-      const color = severityColor[issue.severity];
-      const icon = severityIcon[issue.severity];
-      const loc = issue.line ? `:${issue.line}` : "";
-      console.log(
-        `  ${color(`${icon} ${issue.code}`)}${loc} ${issue.message}`
-      );
-      const remediation = remediationFor(issue.code);
-      if (remediation) console.log(chalk.dim(`    → ${remediation}`));
+        const color = severityColor[issue.severity];
+        const icon = severityIcon[issue.severity];
+        const loc = issue.line ? `:${issue.line}` : "";
+        console.log(
+          `  ${color(`${icon} ${issue.code}`)}${loc} ${issue.message}`
+        );
+        const remediation = remediationFor(issue.code);
+        if (remediation) console.log(chalk.dim(`    → ${remediation}`));
       }
       console.log();
     }

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -20,19 +20,27 @@ export function reportConsole(report: DriftReport): void {
     console.log();
   }
 
-  const grouped = groupByFile(report.issues);
+  const grouped = groupBySeverityThenFile(report.issues);
 
-  for (const [file, issues] of Object.entries(grouped)) {
-    console.log(chalk.bold.underline(file));
-    for (const issue of issues) {
+  for (const severity of ["error", "warning", "info"] as Severity[]) {
+    const files = grouped[severity];
+    if (!files || Object.keys(files).length === 0) continue;
+    console.log(chalk.bold(severity.toUpperCase()));
+    console.log();
+    for (const [file, issues] of Object.entries(files)) {
+      console.log(chalk.bold.underline(file));
+      for (const issue of issues) {
       const color = severityColor[issue.severity];
       const icon = severityIcon[issue.severity];
       const loc = issue.line ? `:${issue.line}` : "";
       console.log(
         `  ${color(`${icon} ${issue.code}`)}${loc} ${issue.message}`
       );
+      const remediation = remediationFor(issue.code);
+      if (remediation) console.log(chalk.dim(`    → ${remediation}`));
+      }
+      console.log();
     }
-    console.log();
   }
 
   printSummary(report);
@@ -91,13 +99,41 @@ function printSummary(report: DriftReport): void {
   console.log(chalk.dim(`${report.filesChecked} files checked`));
 }
 
-function groupByFile(
+function groupBySeverityThenFile(
   issues: DriftIssue[]
-): Record<string, DriftIssue[]> {
-  const grouped: Record<string, DriftIssue[]> = {};
+): Record<Severity, Record<string, DriftIssue[]>> {
+  const grouped: Record<Severity, Record<string, DriftIssue[]>> = {
+    error: {},
+    warning: {},
+    info: {},
+  };
   for (const issue of issues) {
-    if (!grouped[issue.file]) grouped[issue.file] = [];
-    grouped[issue.file].push(issue);
+    if (!grouped[issue.severity][issue.file]) grouped[issue.severity][issue.file] = [];
+    grouped[issue.severity][issue.file].push(issue);
   }
   return grouped;
+}
+
+function remediationFor(code: DriftIssue["code"]): string | null {
+  switch (code) {
+    case "STALE_FILE":
+      return "Review the file against reality, update it if needed, then bump last_updated.";
+    case "MISSING_PATH":
+      return "Fix the referenced path or remove stale documentation.";
+    case "DEAD_COMMAND":
+      return "Update the command in the scaffold or restore the missing script.";
+    case "DEPENDENCY_MISSING":
+      return "Remove the dependency claim or add the dependency to the manifest.";
+    case "DEAD_EDGE":
+      return "Update or remove the frontmatter edge target.";
+    case "INDEX_MISSING_ENTRY":
+    case "INDEX_ORPHAN_ENTRY":
+      return "Update patterns/INDEX.md to match the pattern files on disk.";
+    case "UNDOCUMENTED_SCRIPT":
+      return "Document the script in AGENTS.md, SETUP.md, or context/setup.md.";
+    case "TOOL_CONFIG_DRIFT":
+      return "Copy the intended tool config text across installed agent config files.";
+    default:
+      return null;
+  }
 }

--- a/src/setup/index.ts
+++ b/src/setup/index.ts
@@ -41,6 +41,11 @@ const SCAFFOLD_FILES = [
   "patterns/INDEX.md",
 ];
 
+const AGENT_MEMORY_FILES = [
+  ...SCAFFOLD_FILES,
+  "HEARTBEAT.md",
+];
+
 const TOOL_CONFIGS: Record<string, { src: string; dest: string }> = {
   "1": { src: ".tool-configs/CLAUDE.md", dest: "CLAUDE.md" },
   "2": { src: ".tool-configs/.cursorrules", dest: ".cursorrules" },
@@ -95,8 +100,11 @@ function banner() {
 
 type ProjectState = "existing" | "fresh" | "partial";
 
-export async function runSetup(opts: { dryRun?: boolean } = {}): Promise<void> {
+type SetupMode = "code-repo" | "agent-memory";
+
+export async function runSetup(opts: { dryRun?: boolean; mode?: string } = {}): Promise<void> {
   const { dryRun = false } = opts;
+  const mode = normalizeMode(opts.mode);
 
   banner();
   console.log();
@@ -133,7 +141,10 @@ export async function runSetup(opts: { dryRun?: boolean } = {}): Promise<void> {
 
   const state = detectProjectState(projectRoot, mexDir);
 
-  switch (state) {
+  if (mode === "agent-memory") {
+    info("Detected: agent-memory workspace");
+    info("Mode: persistent-agent operational memory");
+  } else switch (state) {
     case "existing":
       info("Detected: existing codebase with source files");
       info("Mode: populate scaffold from code");
@@ -154,8 +165,12 @@ export async function runSetup(opts: { dryRun?: boolean } = {}): Promise<void> {
   header("Creating .mex/ scaffold...");
   console.log();
 
-  for (const file of SCAFFOLD_FILES) {
-    const src = resolve(TEMPLATES_DIR, file);
+  const scaffoldFiles = mode === "agent-memory" ? AGENT_MEMORY_FILES : SCAFFOLD_FILES;
+  for (const file of scaffoldFiles) {
+    const agentMemorySrc = resolve(TEMPLATES_DIR, "agent-memory", file);
+    const src = mode === "agent-memory" && existsSync(agentMemorySrc)
+      ? agentMemorySrc
+      : resolve(TEMPLATES_DIR, file);
     const dest = resolve(mexDir, file);
 
     if (existsSync(dest)) {
@@ -195,7 +210,7 @@ export async function runSetup(opts: { dryRun?: boolean } = {}): Promise<void> {
 
   let scannerBrief: string | null = null;
 
-  if (state !== "fresh") {
+  if (mode !== "agent-memory" && state !== "fresh") {
     try {
       info("Scanning codebase...");
       const { runScan } = await import("../scanner/index.js");
@@ -211,7 +226,10 @@ export async function runSetup(opts: { dryRun?: boolean } = {}): Promise<void> {
   // ── Step 5: Build population prompt ──
 
   let prompt: string;
-  if (state === "fresh") {
+  if (mode === "agent-memory") {
+    const { buildAgentMemoryPrompt } = await import("./prompts.js");
+    prompt = buildAgentMemoryPrompt();
+  } else if (state === "fresh") {
     prompt = buildFreshPrompt();
   } else if (scannerBrief) {
     prompt = buildExistingWithBriefPrompt(scannerBrief);
@@ -269,6 +287,12 @@ export async function runSetup(opts: { dryRun?: boolean } = {}): Promise<void> {
   }
 
   await promptGlobalInstall();
+}
+
+function normalizeMode(raw: string | undefined): SetupMode {
+  const mode = raw ?? "code-repo";
+  if (mode === "code-repo" || mode === "agent-memory") return mode;
+  throw new Error(`Unknown setup mode "${mode}". Use code-repo or agent-memory.`);
 }
 
 // ── Step functions ──

--- a/src/setup/index.ts
+++ b/src/setup/index.ts
@@ -144,19 +144,21 @@ export async function runSetup(opts: { dryRun?: boolean; mode?: string } = {}): 
   if (mode === "agent-memory") {
     info("Detected: agent-memory workspace");
     info("Mode: persistent-agent operational memory");
-  } else switch (state) {
-    case "existing":
-      info("Detected: existing codebase with source files");
-      info("Mode: populate scaffold from code");
-      break;
-    case "fresh":
-      info("Detected: fresh project (no source files yet)");
-      info("Mode: populate scaffold from intent");
-      break;
-    case "partial":
-      info("Detected: existing codebase with partially populated scaffold");
-      info("Mode: will populate empty slots, skip what's already filled");
-      break;
+  } else {
+    switch (state) {
+      case "existing":
+        info("Detected: existing codebase with source files");
+        info("Mode: populate scaffold from code");
+        break;
+      case "fresh":
+        info("Detected: fresh project (no source files yet)");
+        info("Mode: populate scaffold from intent");
+        break;
+      case "partial":
+        info("Detected: existing codebase with partially populated scaffold");
+        info("Mode: will populate empty slots, skip what's already filled");
+        break;
+    }
   }
   console.log();
 

--- a/src/setup/prompts.ts
+++ b/src/setup/prompts.ts
@@ -198,3 +198,41 @@ PASS 1 — Populate knowledge files:
 ${EXISTING_PASS_1}
 ${EXISTING_PASSES_2_3}`;
 }
+
+export function buildAgentMemoryPrompt(): string {
+  return `You are going to populate a mex scaffold for a persistent AI agent workspace.
+This is not primarily a code repository. The scaffold describes an operational
+environment, the agent's working memory, recurring maintenance routines, and
+the patterns the agent should reuse across sessions.
+
+Read these files first:
+1. .mex/AGENTS.md — compact operating contract and GROW checklist
+2. .mex/ROUTER.md — session bootstrap and routing table
+3. .mex/HEARTBEAT.md — lightweight periodic health checks
+4. .mex/context/*.md — fill the annotated context files
+5. .mex/patterns/README.md — pattern format
+
+Populate the scaffold for the agent-memory use case:
+- ROUTER.md: current operational state, active systems, known issues, routing table
+- context/architecture.md: services, machines, containers, automations, data flows
+- context/stack.md: models, tools, runtimes, storage, important versions
+- context/conventions.md: naming, safety rules, operational habits
+- context/decisions.md: key decisions and rationale that should not be re-litigated
+- context/setup.md: how to inspect, run, restart, and recover the environment
+- HEARTBEAT.md: concrete checks the agent should run when polled on a heartbeat
+- patterns/: 3-5 operational runbooks for recurring maintenance/debug tasks
+
+Use the GROW loop exactly:
+G — Ground: identify what changed in reality.
+R — Record: update ROUTER.md and relevant context files with current truth.
+O — Orient: create or update a pattern when the task can recur.
+W — Write: bump last_updated on changed scaffold files and run mex log for rationale.
+
+Event guidance:
+- Use state files for current truth.
+- Use mex log for decisions, risks, todos, and notes about why something changed.
+- Do not rewrite history out of decisions.md; supersede old decisions instead.
+
+Do not invent cloud services, servers, models, or schedules. If something is
+unknown, write [TO DETERMINE] and say what needs to be inspected.`;
+}

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -245,9 +245,12 @@ function BrandHeader({ scaffoldRoot }: { scaffoldRoot: string }) {
 
 export function SetupBanner() {
   return h(Box, { flexDirection: "column" },
-    h(Text, { color: COLORS.royal }, "╔╦╗ ╔═╗ ═╗ ╦"),
-    h(Text, { color: COLORS.royal }, "║║║ ║╣  ╔╩╦╝"),
-    h(Text, { color: COLORS.royal }, "╩ ╩ ╚═╝ ╩ ╚═"),
+    h(Text, { color: COLORS.royal }, "███╗   ███╗███████╗██╗  ██╗"),
+    h(Text, { color: COLORS.royal }, "████╗ ████║██╔════╝╚██╗██╔╝"),
+    h(Text, { color: COLORS.royal }, "██╔████╔██║█████╗   ╚███╔╝"),
+    h(Text, { color: COLORS.royal }, "██║╚██╔╝██║██╔══╝   ██╔██╗"),
+    h(Text, { color: COLORS.royal }, "██║ ╚═╝ ██║███████╗██╔╝ ██╗"),
+    h(Text, { color: COLORS.royal }, "╚═╝     ╚═╝╚══════╝╚═╝  ╚═╝"),
   );
 }
 

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -46,7 +46,7 @@ const COLORS = {
   shellDark: "#4A7A49",
   crab: "#E8845C",
   ink: "#3D3D3D",
-  scroll: "#F5E6C8",
+  royal: "#1944F1",
 };
 const BAR_WIDTH = 18;
 const ACTIVITY_DAYS = 7;
@@ -227,36 +227,50 @@ export function Summary({ data, notice }: { data: DashboardData; notice: string 
 }
 
 function BrandHeader({ scaffoldRoot }: { scaffoldRoot: string }) {
-  return h(Box, { flexDirection: "row" },
-    h(Mascot, null),
-    h(Box, { marginLeft: 2, flexDirection: "column" },
-      h(Text, null,
-        h(Text, { bold: true, color: COLORS.shell }, "mex"),
-        h(Text, { color: COLORS.crab }, " operational memory"),
-      ),
-      h(Text, { dimColor: true }, "drift, heartbeat, and event log at a glance"),
-      h(Text, { dimColor: true }, `Scaffold: ${scaffoldRoot}`),
+  return h(Box, { flexDirection: "column" },
+    h(SetupBanner, null),
+    h(Text, null,
+      h(Text, { bold: true }, "operational memory dashboard"),
+      h(Text, { dimColor: true }, " · drift, heartbeat, and events"),
     ),
+    h(Text, { dimColor: true }, `Scaffold: ${scaffoldRoot}`),
   );
 }
 
-export function Mascot() {
+export function SetupBanner() {
   return h(Box, { flexDirection: "column" },
-    h(Text, null, h(Text, { color: COLORS.shell }, "   ██████")),
-    h(Text, null, h(Text, { color: COLORS.shell }, " ██████████")),
     h(Text, null,
-      h(Text, { color: COLORS.crab }, "████████████"),
-      h(Text, { color: COLORS.scroll }, " ▐"),
+      h(Text, { color: COLORS.shell }, "     ████      "),
+      h(Text, { color: COLORS.royal }, "███╗   ███╗███████╗██╗  ██╗"),
     ),
     h(Text, null,
+      h(Text, { color: COLORS.shell }, "    █"),
+      h(Text, { color: COLORS.shellDark }, "█"),
+      h(Text, { color: COLORS.shell }, "██"),
+      h(Text, { color: COLORS.shellDark }, "█"),
+      h(Text, { color: COLORS.shell }, "█     "),
+      h(Text, { color: COLORS.royal }, "████╗ ████║██╔════╝╚██╗██╔╝"),
+    ),
+    h(Text, null,
+      h(Text, { color: COLORS.crab }, "  ██████████   "),
+      h(Text, { color: COLORS.royal }, "██╔████╔██║█████╗   ╚███╔╝"),
+    ),
+    h(Text, null,
+      h(Text, { color: COLORS.crab }, "█ ██"),
+      h(Text, { color: COLORS.ink }, "██"),
       h(Text, { color: COLORS.crab }, "██"),
-      h(Text, { color: COLORS.ink }, "▣"),
-      h(Text, { color: COLORS.crab }, "━━"),
-      h(Text, { color: COLORS.ink }, "▣"),
-      h(Text, { color: COLORS.crab }, "████"),
-      h(Text, { color: COLORS.scroll }, " ▐"),
+      h(Text, { color: COLORS.ink }, "██"),
+      h(Text, { color: COLORS.crab }, "██ █ "),
+      h(Text, { color: COLORS.royal }, "██║╚██╔╝██║██╔══╝   ██╔██╗"),
     ),
-    h(Text, null, h(Text, { color: COLORS.crab }, "  ████████")),
+    h(Text, null,
+      h(Text, { color: COLORS.crab }, "█ ██████████ █ "),
+      h(Text, { color: COLORS.royal }, "██║ ╚═╝ ██║███████╗██╔╝ ██╗"),
+    ),
+    h(Text, null,
+      h(Text, { color: COLORS.crab }, "   █ █  █ █    "),
+      h(Text, { color: COLORS.royal }, "╚═╝     ╚═╝╚══════╝╚═╝  ╚═╝"),
+    ),
   );
 }
 

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -43,9 +43,7 @@ const MENU = [
 const EVENT_KINDS: EventKind[] = ["note", "decision", "risk", "todo"];
 const COLORS = {
   shell: "#5B8C5A",
-  shellDark: "#4A7A49",
   crab: "#E8845C",
-  ink: "#3D3D3D",
   royal: "#1944F1",
 };
 const BAR_WIDTH = 18;
@@ -171,7 +169,15 @@ function TuiApp({ config }: { config: MexConfig }) {
     h(Summary, { data: state.data, notice: state.notice }),
     h(Box, { marginTop: 1 },
       h(Menu, { selected: state.selected, active: state.view === "dashboard" }),
-      h(Box, { marginLeft: 4, flexDirection: "column" },
+      h(Box, {
+        borderStyle: "single",
+        borderColor: COLORS.royal,
+        flexDirection: "column",
+        marginLeft: 2,
+        minWidth: 46,
+        paddingX: 1,
+        paddingY: 0,
+      },
         h(ViewPanel, { state, data: state.data }),
       ),
     ),
@@ -239,38 +245,9 @@ function BrandHeader({ scaffoldRoot }: { scaffoldRoot: string }) {
 
 export function SetupBanner() {
   return h(Box, { flexDirection: "column" },
-    h(Text, null,
-      h(Text, { color: COLORS.shell }, "     ████      "),
-      h(Text, { color: COLORS.royal }, "███╗   ███╗███████╗██╗  ██╗"),
-    ),
-    h(Text, null,
-      h(Text, { color: COLORS.shell }, "    █"),
-      h(Text, { color: COLORS.shellDark }, "█"),
-      h(Text, { color: COLORS.shell }, "██"),
-      h(Text, { color: COLORS.shellDark }, "█"),
-      h(Text, { color: COLORS.shell }, "█     "),
-      h(Text, { color: COLORS.royal }, "████╗ ████║██╔════╝╚██╗██╔╝"),
-    ),
-    h(Text, null,
-      h(Text, { color: COLORS.crab }, "  ██████████   "),
-      h(Text, { color: COLORS.royal }, "██╔████╔██║█████╗   ╚███╔╝"),
-    ),
-    h(Text, null,
-      h(Text, { color: COLORS.crab }, "█ ██"),
-      h(Text, { color: COLORS.ink }, "██"),
-      h(Text, { color: COLORS.crab }, "██"),
-      h(Text, { color: COLORS.ink }, "██"),
-      h(Text, { color: COLORS.crab }, "██ █ "),
-      h(Text, { color: COLORS.royal }, "██║╚██╔╝██║██╔══╝   ██╔██╗"),
-    ),
-    h(Text, null,
-      h(Text, { color: COLORS.crab }, "█ ██████████ █ "),
-      h(Text, { color: COLORS.royal }, "██║ ╚═╝ ██║███████╗██╔╝ ██╗"),
-    ),
-    h(Text, null,
-      h(Text, { color: COLORS.crab }, "   █ █  █ █    "),
-      h(Text, { color: COLORS.royal }, "╚═╝     ╚═╝╚══════╝╚═╝  ╚═╝"),
-    ),
+    h(Text, { color: COLORS.royal }, "╔╦╗ ╔═╗ ═╗ ╦"),
+    h(Text, { color: COLORS.royal }, "║║║ ║╣  ╔╩╦╝"),
+    h(Text, { color: COLORS.royal }, "╩ ╩ ╚═╝ ╩ ╚═"),
   );
 }
 

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -41,6 +41,15 @@ const MENU = [
 ] as const;
 
 const EVENT_KINDS: EventKind[] = ["note", "decision", "risk", "todo"];
+const COLORS = {
+  shell: "#5B8C5A",
+  shellDark: "#4A7A49",
+  crab: "#E8845C",
+  ink: "#3D3D3D",
+  scroll: "#F5E6C8",
+};
+const BAR_WIDTH = 18;
+const ACTIVITY_DAYS = 7;
 
 export function launchTui(): void {
   if (!stdin.isTTY || !stdout.isTTY) {
@@ -105,6 +114,10 @@ function TuiApp({ config }: { config: MexConfig }) {
         setState((s) => ({ ...s, selected: Math.max(0, s.selected - 1) }));
       } else if (key.downArrow) {
         setState((s) => ({ ...s, selected: Math.min(MENU.length - 1, s.selected + 1) }));
+      } else if (input === "r") {
+        void refresh("dashboard", "Dashboard refreshed");
+      } else if (input === "l") {
+        setState((s) => ({ ...s, view: "log-kind", notice: null }));
       } else if (key.return) {
         const action = MENU[state.selected];
         if (action === "Refresh dashboard") void refresh("dashboard", "Dashboard refreshed");
@@ -162,7 +175,7 @@ function TuiApp({ config }: { config: MexConfig }) {
         h(ViewPanel, { state, data: state.data }),
       ),
     ),
-    h(Box, { marginTop: 1 }, h(Text, { dimColor: true }, "↑/↓ navigate · enter select · esc dashboard · q quit")),
+    h(Box, { marginTop: 1 }, h(Text, { dimColor: true }, "↑/↓ choose · enter run · r refresh · l log · esc dashboard · q quit")),
   );
 }
 
@@ -176,8 +189,7 @@ export function ErrorScreen({ message }: { message: string }) {
 
 function Frame({ config, children }: { config: MexConfig; children?: React.ReactNode }) {
   return h(Box, { flexDirection: "column", paddingX: 1 },
-    h(Text, { bold: true, color: "cyan" }, "mex"),
-    h(Text, { dimColor: true }, `Scaffold: ${config.scaffoldRoot}`),
+    h(BrandHeader, { scaffoldRoot: config.scaffoldRoot }),
     h(Box, { marginTop: 1, flexDirection: "column" }, children),
   );
 }
@@ -186,18 +198,99 @@ export function Summary({ data, notice }: { data: DashboardData; notice: string 
   const errors = data.report.issues.filter((i) => i.severity === "error").length;
   const warnings = data.report.issues.filter((i) => i.severity === "warning").length;
   const scoreColor = data.report.score >= 80 ? "green" : data.report.score >= 50 ? "yellow" : "red";
+  const heartbeatColor = data.heartbeat.ok ? "green" : "yellow";
+  const heartbeatValue = data.heartbeat.ok ? 100 : Math.max(10, 100 - data.heartbeat.staleFiles.length * 25);
+  const activity = eventActivityBars(data.events);
   return h(Box, { flexDirection: "column" },
     notice ? h(Text, { color: "green" }, notice) : null,
+    h(StatusLine, {
+      label: "Drift",
+      value: `${data.report.score}/100`,
+      bar: progressBar(data.report.score),
+      color: scoreColor,
+      detail: `${errors} errors · ${warnings} warnings · ${data.report.filesChecked} files`,
+    }),
+    h(StatusLine, {
+      label: "Heartbeat",
+      value: data.heartbeat.ok ? "OK" : "Attention",
+      bar: progressBar(heartbeatValue),
+      color: heartbeatColor,
+      detail: `${data.heartbeat.staleFiles.length} stale files`,
+    }),
     h(Text, null,
-      h(Text, { color: scoreColor, bold: true }, `Drift ${data.report.score}/100`),
-      `  ${errors} errors, ${warnings} warnings, ${data.report.filesChecked} files checked`,
+      h(Text, { color: COLORS.shell, bold: true }, "Events    "),
+      h(Text, { bold: true }, String(data.events.length).padEnd(9)),
+      h(Text, { color: COLORS.crab }, activity),
+      `  last 7d · latest ${latestEvent(data.events)}`,
     ),
-    h(Text, null,
-      h(Text, { color: data.heartbeat.ok ? "green" : "yellow", bold: true }, data.heartbeat.ok ? "Heartbeat OK" : "Heartbeat needs attention"),
-      `  ${data.heartbeat.staleFiles.length} stale files`,
-    ),
-    h(Text, null, `Events ${data.events.length} logged · latest ${latestEvent(data.events)}`),
   );
+}
+
+function BrandHeader({ scaffoldRoot }: { scaffoldRoot: string }) {
+  return h(Box, { flexDirection: "row" },
+    h(Mascot, null),
+    h(Box, { marginLeft: 2, flexDirection: "column" },
+      h(Text, null,
+        h(Text, { bold: true, color: COLORS.shell }, "mex"),
+        h(Text, { color: COLORS.crab }, " operational memory"),
+      ),
+      h(Text, { dimColor: true }, "drift, heartbeat, and event log at a glance"),
+      h(Text, { dimColor: true }, `Scaffold: ${scaffoldRoot}`),
+    ),
+  );
+}
+
+export function Mascot() {
+  return h(Box, { flexDirection: "column" },
+    h(Text, null, h(Text, { color: COLORS.shell }, "   ██████")),
+    h(Text, null, h(Text, { color: COLORS.shell }, " ██████████")),
+    h(Text, null,
+      h(Text, { color: COLORS.crab }, "████████████"),
+      h(Text, { color: COLORS.scroll }, " ▐"),
+    ),
+    h(Text, null,
+      h(Text, { color: COLORS.crab }, "██"),
+      h(Text, { color: COLORS.ink }, "▣"),
+      h(Text, { color: COLORS.crab }, "━━"),
+      h(Text, { color: COLORS.ink }, "▣"),
+      h(Text, { color: COLORS.crab }, "████"),
+      h(Text, { color: COLORS.scroll }, " ▐"),
+    ),
+    h(Text, null, h(Text, { color: COLORS.crab }, "  ████████")),
+  );
+}
+
+function StatusLine({ label, value, bar, color, detail }: { label: string; value: string; bar: string; color: string; detail: string }) {
+  return h(Text, null,
+    h(Text, { color, bold: true }, label.padEnd(10)),
+    h(Text, { bold: true }, value.padEnd(9)),
+    h(Text, { color }, bar),
+    `  ${detail}`,
+  );
+}
+
+export function progressBar(value: number, width = BAR_WIDTH): string {
+  const clamped = Math.max(0, Math.min(100, value));
+  const filled = Math.round((clamped / 100) * width);
+  return `${"█".repeat(filled)}${"░".repeat(width - filled)}`;
+}
+
+export function eventActivityBars(events: EventEntry[], days = ACTIVITY_DAYS, now = new Date()): string {
+  const counts = Array.from({ length: days }, () => 0);
+  const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  start.setUTCDate(start.getUTCDate() - (days - 1));
+
+  for (const event of events) {
+    const timestamp = new Date(event.timestamp);
+    if (Number.isNaN(timestamp.getTime())) continue;
+    const day = new Date(Date.UTC(timestamp.getUTCFullYear(), timestamp.getUTCMonth(), timestamp.getUTCDate()));
+    const offset = Math.floor((day.getTime() - start.getTime()) / 86_400_000);
+    if (offset >= 0 && offset < days) counts[offset] += 1;
+  }
+
+  const max = Math.max(...counts, 1);
+  const levels = "▁▂▃▄▅▆▇█";
+  return counts.map((count) => levels[Math.ceil((count / max) * (levels.length - 1))] ?? levels[0]).join("");
 }
 
 function Menu({ selected, active }: { selected: number; active: boolean }) {
@@ -228,7 +321,7 @@ function CheckPanel({ data }: { data: DashboardData }) {
   return h(Box, { flexDirection: "column" },
     h(Text, { bold: true }, "Check summary"),
     issues.length === 0
-      ? h(Text, { color: "green" }, "No drift issues found.")
+      ? h(Text, { color: "green" }, "No drift issues found. Scaffold is calm.")
       : issues.map((i, idx) => h(Text, { key: `${i.file}-${idx}` }, `${i.severity.toUpperCase()} ${i.code} ${i.file}: ${i.message}`)),
   );
 }
@@ -236,7 +329,7 @@ function CheckPanel({ data }: { data: DashboardData }) {
 export function HeartbeatPanel({ data }: { data: DashboardData }) {
   return h(Box, { flexDirection: "column" },
     h(Text, { bold: true }, "Heartbeat"),
-    data.heartbeat.ok ? h(Text, { color: "green" }, "HEARTBEAT_OK") : null,
+    data.heartbeat.ok ? h(Text, { color: "green" }, "HEARTBEAT_OK · scaffold is fresh") : null,
     ...data.heartbeat.staleFiles.map((f) => h(Text, { key: f.file }, `Stale ${f.file} (${f.days} days)`)),
     data.heartbeat.memoryCleanupDue ? h(Text, null, "Memory cleanup is due.") : null,
     ...data.heartbeat.oldDailyMemoryFiles.map((f) => h(Text, { key: f }, `Old memory ${f}`)),
@@ -261,7 +354,7 @@ export function TimelinePanel({ data }: { data: DashboardData }) {
   return h(Box, { flexDirection: "column" },
     h(Text, { bold: true }, "Timeline"),
     events.length === 0
-      ? h(Text, { dimColor: true }, "No events logged yet.")
+      ? h(Text, { dimColor: true }, "No events yet. Use Log event when the why matters.")
       : events.map((e) => h(Text, { key: `${e.timestamp}-${e.message}` }, `${e.timestamp.slice(0, 10)} ${e.kind} ${e.message}`)),
   );
 }

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -142,21 +142,36 @@ function TuiApp({ config }: { config: MexConfig }) {
     }
 
     if (state.view === "log-message" || state.view === "log-file") {
-      const field = state.view === "log-message" ? "logMessage" : "logFile";
       if (key.backspace || key.delete) {
-        setState((s) => ({ ...s, [field]: s[field].slice(0, -1) }));
+        if (state.view === "log-message") {
+          setState((s) => ({ ...s, logMessage: s.logMessage.slice(0, -1) }));
+        } else {
+          setState((s) => ({ ...s, logFile: s.logFile.slice(0, -1) }));
+        }
       } else if (key.return) {
         if (state.view === "log-message") {
           if (state.logMessage.trim().length > 0) setState((s) => ({ ...s, view: "log-file" }));
         } else {
-          appendEvent(config, state.logMessage.trim(), {
-            kind: state.logKind,
-            files: state.logFile.trim() ? [state.logFile.trim()] : [],
-          });
-          void refresh("log-done", `Logged ${state.logKind}`);
+          try {
+            appendEvent(config, state.logMessage.trim(), {
+              kind: state.logKind,
+              files: state.logFile.trim() ? [state.logFile.trim()] : [],
+            });
+            void refresh("log-done", `Logged ${state.logKind}`);
+          } catch (err) {
+            setState((s) => ({
+              ...s,
+              view: "dashboard",
+              notice: `Log failed: ${(err as Error).message}`,
+            }));
+          }
         }
       } else if (input && !key.ctrl && !key.meta) {
-        setState((s) => ({ ...s, [field]: s[field] + input }));
+        if (state.view === "log-message") {
+          setState((s) => ({ ...s, logMessage: s.logMessage + input }));
+        } else {
+          setState((s) => ({ ...s, logFile: s.logFile + input }));
+        }
       }
     }
   });
@@ -214,14 +229,14 @@ export function Summary({ data, notice }: { data: DashboardData; notice: string 
       value: `${data.report.score}/100`,
       bar: progressBar(data.report.score),
       color: scoreColor,
-      detail: `${errors} errors · ${warnings} warnings · ${data.report.filesChecked} files`,
+      detail: `${formatCount(errors, "error")} · ${formatCount(warnings, "warning")} · ${formatCount(data.report.filesChecked, "file")}`,
     }),
     h(StatusLine, {
       label: "Heartbeat",
       value: data.heartbeat.ok ? "OK" : "Attention",
       bar: progressBar(heartbeatValue),
       color: heartbeatColor,
-      detail: `${data.heartbeat.staleFiles.length} stale files`,
+      detail: `${formatCount(data.heartbeat.staleFiles.length, "stale file")}`,
     }),
     h(Text, null,
       h(Text, { color: COLORS.shell, bold: true }, "Events    "),
@@ -261,6 +276,10 @@ function StatusLine({ label, value, bar, color, detail }: { label: string; value
     h(Text, { color }, bar),
     `  ${detail}`,
   );
+}
+
+function formatCount(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
 }
 
 export function progressBar(value: number, width = BAR_WIDTH): string {

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -1,0 +1,282 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { render, Box, Text, useApp, useInput } from "ink";
+import { stdin, stdout } from "node:process";
+import type { DriftReport, MexConfig } from "./types.js";
+import { findConfig } from "./config.js";
+import { runDriftCheck } from "./drift/index.js";
+import { checkHeartbeat, type HeartbeatResult } from "./heartbeat.js";
+import { appendEvent, readEvents, type EventEntry, type EventKind } from "./events.js";
+
+const h = React.createElement;
+
+type View = "dashboard" | "check" | "heartbeat" | "doctor" | "timeline" | "log-kind" | "log-message" | "log-file" | "log-done";
+type LoadState = "loading" | "ready" | "error";
+
+export interface DashboardData {
+  report: DriftReport;
+  heartbeat: HeartbeatResult;
+  events: EventEntry[];
+}
+
+interface AppState {
+  view: View;
+  selected: number;
+  loadState: LoadState;
+  data: DashboardData | null;
+  error: string | null;
+  logKind: EventKind;
+  logMessage: string;
+  logFile: string;
+  notice: string | null;
+}
+
+const MENU = [
+  "Refresh dashboard",
+  "Run check summary",
+  "Run heartbeat",
+  "Run doctor summary",
+  "View timeline",
+  "Log event",
+  "Exit",
+] as const;
+
+const EVENT_KINDS: EventKind[] = ["note", "decision", "risk", "todo"];
+
+export function launchTui(): void {
+  if (!stdin.isTTY || !stdout.isTTY) {
+    console.log("mex TUI requires an interactive terminal. Run `mex commands` to list CLI commands.");
+    return;
+  }
+  try {
+    const config = findConfig();
+    render(h(TuiApp, { config }));
+  } catch (err) {
+    render(h(ErrorScreen, { message: (err as Error).message }));
+  }
+}
+
+export async function loadDashboard(config: MexConfig): Promise<DashboardData> {
+  const report = await runDriftCheck(config);
+  const heartbeat = checkHeartbeat(config);
+  const events = readEvents(config).sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+  return { report, heartbeat, events };
+}
+
+function TuiApp({ config }: { config: MexConfig }) {
+  const { exit } = useApp();
+  const [state, setState] = useState<AppState>({
+    view: "dashboard",
+    selected: 0,
+    loadState: "loading",
+    data: null,
+    error: null,
+    logKind: "note",
+    logMessage: "",
+    logFile: "",
+    notice: null,
+  });
+
+  const refresh = async (view: View = "dashboard", notice: string | null = null) => {
+    setState((s) => ({ ...s, view, loadState: "loading", error: null, notice }));
+    try {
+      const data = await loadDashboard(config);
+      setState((s) => ({ ...s, data, loadState: "ready", error: null, notice }));
+    } catch (err) {
+      setState((s) => ({ ...s, loadState: "error", error: (err as Error).message }));
+    }
+  };
+
+  useEffect(() => {
+    void refresh();
+  }, []);
+
+  useInput((input, key) => {
+    if (input === "q" && state.view !== "log-message" && state.view !== "log-file") {
+      exit();
+      return;
+    }
+    if (key.escape) {
+      setState((s) => ({ ...s, view: "dashboard", notice: null }));
+      return;
+    }
+
+    if (state.view === "dashboard") {
+      if (key.upArrow) {
+        setState((s) => ({ ...s, selected: Math.max(0, s.selected - 1) }));
+      } else if (key.downArrow) {
+        setState((s) => ({ ...s, selected: Math.min(MENU.length - 1, s.selected + 1) }));
+      } else if (key.return) {
+        const action = MENU[state.selected];
+        if (action === "Refresh dashboard") void refresh("dashboard", "Dashboard refreshed");
+        if (action === "Run check summary") setState((s) => ({ ...s, view: "check", notice: null }));
+        if (action === "Run heartbeat") setState((s) => ({ ...s, view: "heartbeat", notice: null }));
+        if (action === "Run doctor summary") setState((s) => ({ ...s, view: "doctor", notice: null }));
+        if (action === "View timeline") setState((s) => ({ ...s, view: "timeline", notice: null }));
+        if (action === "Log event") setState((s) => ({ ...s, view: "log-kind", notice: null }));
+        if (action === "Exit") exit();
+      }
+      return;
+    }
+
+    if (state.view === "log-kind") {
+      const idx = EVENT_KINDS.indexOf(state.logKind);
+      if (key.leftArrow || key.upArrow) {
+        setState((s) => ({ ...s, logKind: EVENT_KINDS[(idx + EVENT_KINDS.length - 1) % EVENT_KINDS.length] }));
+      } else if (key.rightArrow || key.downArrow) {
+        setState((s) => ({ ...s, logKind: EVENT_KINDS[(idx + 1) % EVENT_KINDS.length] }));
+      } else if (key.return) {
+        setState((s) => ({ ...s, view: "log-message", logMessage: "", logFile: "" }));
+      }
+      return;
+    }
+
+    if (state.view === "log-message" || state.view === "log-file") {
+      const field = state.view === "log-message" ? "logMessage" : "logFile";
+      if (key.backspace || key.delete) {
+        setState((s) => ({ ...s, [field]: s[field].slice(0, -1) }));
+      } else if (key.return) {
+        if (state.view === "log-message") {
+          if (state.logMessage.trim().length > 0) setState((s) => ({ ...s, view: "log-file" }));
+        } else {
+          appendEvent(config, state.logMessage.trim(), {
+            kind: state.logKind,
+            files: state.logFile.trim() ? [state.logFile.trim()] : [],
+          });
+          void refresh("log-done", `Logged ${state.logKind}`);
+        }
+      } else if (input && !key.ctrl && !key.meta) {
+        setState((s) => ({ ...s, [field]: s[field] + input }));
+      }
+    }
+  });
+
+  if (state.loadState === "loading" && !state.data) return h(Frame, { config }, h(Text, null, "Loading mex dashboard..."));
+  if (state.loadState === "error") return h(Frame, { config }, h(Text, { color: "red" }, state.error ?? "Unknown error"));
+  if (!state.data) return h(Frame, { config }, h(Text, null, "No dashboard data."));
+
+  return h(Frame, { config },
+    h(Summary, { data: state.data, notice: state.notice }),
+    h(Box, { marginTop: 1 },
+      h(Menu, { selected: state.selected, active: state.view === "dashboard" }),
+      h(Box, { marginLeft: 4, flexDirection: "column" },
+        h(ViewPanel, { state, data: state.data }),
+      ),
+    ),
+    h(Box, { marginTop: 1 }, h(Text, { dimColor: true }, "↑/↓ navigate · enter select · esc dashboard · q quit")),
+  );
+}
+
+export function ErrorScreen({ message }: { message: string }) {
+  return h(Box, { flexDirection: "column", paddingX: 1 },
+    h(Text, { color: "red", bold: true }, "mex dashboard could not start"),
+    h(Text, null, message),
+    h(Box, { marginTop: 1 }, h(Text, { dimColor: true }, "Run from a project root with a complete .mex scaffold, or run `mex setup`.")),
+  );
+}
+
+function Frame({ config, children }: { config: MexConfig; children?: React.ReactNode }) {
+  return h(Box, { flexDirection: "column", paddingX: 1 },
+    h(Text, { bold: true, color: "cyan" }, "mex"),
+    h(Text, { dimColor: true }, `Scaffold: ${config.scaffoldRoot}`),
+    h(Box, { marginTop: 1, flexDirection: "column" }, children),
+  );
+}
+
+export function Summary({ data, notice }: { data: DashboardData; notice: string | null }) {
+  const errors = data.report.issues.filter((i) => i.severity === "error").length;
+  const warnings = data.report.issues.filter((i) => i.severity === "warning").length;
+  const scoreColor = data.report.score >= 80 ? "green" : data.report.score >= 50 ? "yellow" : "red";
+  return h(Box, { flexDirection: "column" },
+    notice ? h(Text, { color: "green" }, notice) : null,
+    h(Text, null,
+      h(Text, { color: scoreColor, bold: true }, `Drift ${data.report.score}/100`),
+      `  ${errors} errors, ${warnings} warnings, ${data.report.filesChecked} files checked`,
+    ),
+    h(Text, null,
+      h(Text, { color: data.heartbeat.ok ? "green" : "yellow", bold: true }, data.heartbeat.ok ? "Heartbeat OK" : "Heartbeat needs attention"),
+      `  ${data.heartbeat.staleFiles.length} stale files`,
+    ),
+    h(Text, null, `Events ${data.events.length} logged · latest ${latestEvent(data.events)}`),
+  );
+}
+
+function Menu({ selected, active }: { selected: number; active: boolean }) {
+  return h(Box, { flexDirection: "column", width: 26 },
+    ...MENU.map((item, idx) => h(Text, { key: item, color: active && idx === selected ? "cyan" : undefined },
+      `${active && idx === selected ? "›" : " "} ${item}`,
+    )),
+  );
+}
+
+function ViewPanel({ state, data }: { state: AppState; data: DashboardData }) {
+  if (state.view === "check") return h(CheckPanel, { data });
+  if (state.view === "heartbeat") return h(HeartbeatPanel, { data });
+  if (state.view === "doctor") return h(DoctorPanel, { data });
+  if (state.view === "timeline") return h(TimelinePanel, { data });
+  if (state.view === "log-kind") return h(LogKindPanel, { kind: state.logKind });
+  if (state.view === "log-message") return h(Text, null, `Message: ${state.logMessage || "_"}`);
+  if (state.view === "log-file") return h(Box, { flexDirection: "column" },
+    h(Text, null, `Related file (optional): ${state.logFile || "_"}`),
+    h(Text, { dimColor: true }, "Press enter to save."),
+  );
+  if (state.view === "log-done") return h(TimelinePanel, { data });
+  return h(Text, { dimColor: true }, "Choose an action.");
+}
+
+function CheckPanel({ data }: { data: DashboardData }) {
+  const issues = data.report.issues.slice(0, 8);
+  return h(Box, { flexDirection: "column" },
+    h(Text, { bold: true }, "Check summary"),
+    issues.length === 0
+      ? h(Text, { color: "green" }, "No drift issues found.")
+      : issues.map((i, idx) => h(Text, { key: `${i.file}-${idx}` }, `${i.severity.toUpperCase()} ${i.code} ${i.file}: ${i.message}`)),
+  );
+}
+
+export function HeartbeatPanel({ data }: { data: DashboardData }) {
+  return h(Box, { flexDirection: "column" },
+    h(Text, { bold: true }, "Heartbeat"),
+    data.heartbeat.ok ? h(Text, { color: "green" }, "HEARTBEAT_OK") : null,
+    ...data.heartbeat.staleFiles.map((f) => h(Text, { key: f.file }, `Stale ${f.file} (${f.days} days)`)),
+    data.heartbeat.memoryCleanupDue ? h(Text, null, "Memory cleanup is due.") : null,
+    ...data.heartbeat.oldDailyMemoryFiles.map((f) => h(Text, { key: f }, `Old memory ${f}`)),
+  );
+}
+
+function DoctorPanel({ data }: { data: DashboardData }) {
+  const errors = data.report.issues.filter((i) => i.severity === "error").length;
+  const warnings = data.report.issues.filter((i) => i.severity === "warning").length;
+  const healthy = errors === 0 && data.heartbeat.ok;
+  return h(Box, { flexDirection: "column" },
+    h(Text, { bold: true }, "Doctor summary"),
+    h(Text, { color: healthy ? "green" : "yellow" }, healthy ? "Scaffold looks healthy." : "Scaffold needs attention."),
+    h(Text, null, `Drift ${data.report.score}/100 (${errors} errors, ${warnings} warnings)`),
+    h(Text, null, data.heartbeat.ok ? "Heartbeat OK" : "Run `mex heartbeat` for details."),
+    h(Text, null, `${data.events.length} logged events`),
+  );
+}
+
+export function TimelinePanel({ data }: { data: DashboardData }) {
+  const events = data.events.slice(0, 8);
+  return h(Box, { flexDirection: "column" },
+    h(Text, { bold: true }, "Timeline"),
+    events.length === 0
+      ? h(Text, { dimColor: true }, "No events logged yet.")
+      : events.map((e) => h(Text, { key: `${e.timestamp}-${e.message}` }, `${e.timestamp.slice(0, 10)} ${e.kind} ${e.message}`)),
+  );
+}
+
+function LogKindPanel({ kind }: { kind: EventKind }) {
+  const rendered = useMemo(() => EVENT_KINDS.map((k) => k === kind ? `[${k}]` : k).join("  "), [kind]);
+  return h(Box, { flexDirection: "column" },
+    h(Text, { bold: true }, "Log event"),
+    h(Text, null, rendered),
+    h(Text, { dimColor: true }, "Use left/right, then enter."),
+  );
+}
+
+function latestEvent(events: EventEntry[]): string {
+  if (!events.length) return "none";
+  const e = events[0];
+  return `${e.timestamp.slice(0, 10)} ${e.kind}`;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,20 @@ export interface StalenessThresholds {
   errorCommits: number;
 }
 
+export interface WatchConfig {
+  /** Default interval, in minutes, for `mex watch --interval` */
+  intervalMinutes?: number;
+}
+
+export interface HeartbeatConfig {
+  /** Days since `last_updated` before heartbeat reports stale context */
+  staleDays?: number;
+  /** Days since memory cleanup before heartbeat reports cleanup due */
+  memoryCleanupDays?: number;
+  /** Daily memory files older than this are considered cleanup candidates */
+  dailyMemoryRetentionDays?: number;
+}
+
 export interface MexConfig {
   /** Absolute path to project root (where .git lives) */
   projectRoot: string;
@@ -42,6 +56,10 @@ export interface MexConfig {
   aiTools: AiTool[];
   /** Staleness thresholds (warn/error for days and commits). Optional. */
   stalenessThresholds?: StalenessThresholds;
+  /** Scheduled check defaults. Optional. */
+  watch?: WatchConfig;
+  /** Agent heartbeat defaults. Optional. */
+  heartbeat?: HeartbeatConfig;
 }
 
 // ── Claims (extracted from markdown) ──

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -2,6 +2,7 @@ import { writeFileSync, readFileSync, existsSync, chmodSync, unlinkSync } from "
 import { resolve } from "node:path";
 import chalk from "chalk";
 import type { MexConfig } from "./types.js";
+import { runHeartbeat } from "./heartbeat.js";
 
 const HOOK_MARKER = "# mex-drift-check";
 
@@ -26,8 +27,13 @@ esac
 
 export async function manageHook(
   config: MexConfig,
-  opts: { uninstall?: boolean }
+  opts: { uninstall?: boolean; intervalMinutes?: number }
 ): Promise<void> {
+  if (opts.intervalMinutes) {
+    await runWatchInterval(config, opts.intervalMinutes);
+    return;
+  }
+
   const hookPath = resolve(config.projectRoot, ".git", "hooks", "post-commit");
 
   if (opts.uninstall) {
@@ -36,6 +42,19 @@ export async function manageHook(
   }
 
   installHook(hookPath, config);
+}
+
+export async function runWatchInterval(config: MexConfig, intervalMinutes: number): Promise<void> {
+  console.log(chalk.green(`mex heartbeat running every ${intervalMinutes} minute${intervalMinutes === 1 ? "" : "s"}. Press Ctrl+C to stop.`));
+  const run = async () => {
+    try {
+      await runHeartbeat(config);
+    } catch (err) {
+      console.error((err as Error).message);
+    }
+  };
+  await run();
+  setInterval(run, intervalMinutes * 60_000);
 }
 
 function installHook(hookPath: string, config: MexConfig): void {

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -46,6 +46,8 @@ export async function manageHook(
 
 export async function runWatchInterval(config: MexConfig, intervalMinutes: number): Promise<void> {
   console.log(chalk.green(`mex heartbeat running every ${intervalMinutes} minute${intervalMinutes === 1 ? "" : "s"}. Press Ctrl+C to stop.`));
+  let stopped = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
   const run = async () => {
     try {
       await runHeartbeat(config);
@@ -53,8 +55,26 @@ export async function runWatchInterval(config: MexConfig, intervalMinutes: numbe
       console.error((err as Error).message);
     }
   };
+
+  const stop = () => {
+    stopped = true;
+    if (timer) clearTimeout(timer);
+    console.log(chalk.dim("mex heartbeat stopped."));
+    process.exit(0);
+  };
+  process.once("SIGINT", stop);
+  process.once("SIGTERM", stop);
+
+  const scheduleNext = () => {
+    if (stopped) return;
+    timer = setTimeout(async () => {
+      await run();
+      scheduleNext();
+    }, intervalMinutes * 60_000);
+  };
+
   await run();
-  setInterval(run, intervalMinutes * 60_000);
+  scheduleNext();
 }
 
 function installHook(hookPath: string, config: MexConfig): void {

--- a/templates/.tool-configs/.cursorrules
+++ b/templates/.tool-configs/.cursorrules
@@ -32,7 +32,11 @@ last_updated: [YYYY-MM-DD]
      - Build: `npm run build` -->
 
 ## After Every Task
-After completing any task: update `.mex/ROUTER.md` project state and any `.mex/` files that are now out of date. If no pattern existed for the task you just completed, create one in `.mex/patterns/`.
+After meaningful work, run GROW:
+- Ground: what changed in reality?
+- Record: update `.mex/ROUTER.md` and relevant `.mex/context/` files
+- Orient: create or update a `.mex/patterns/` runbook if this can recur
+- Write: bump `last_updated` on changed scaffold files and run `mex log` when rationale matters
 
 ## Navigation
 At the start of every session, read `.mex/ROUTER.md` before doing anything else.

--- a/templates/.tool-configs/.windsurfrules
+++ b/templates/.tool-configs/.windsurfrules
@@ -32,7 +32,11 @@ last_updated: [YYYY-MM-DD]
      - Build: `npm run build` -->
 
 ## After Every Task
-After completing any task: update `.mex/ROUTER.md` project state and any `.mex/` files that are now out of date. If no pattern existed for the task you just completed, create one in `.mex/patterns/`.
+After meaningful work, run GROW:
+- Ground: what changed in reality?
+- Record: update `.mex/ROUTER.md` and relevant `.mex/context/` files
+- Orient: create or update a `.mex/patterns/` runbook if this can recur
+- Write: bump `last_updated` on changed scaffold files and run `mex log` when rationale matters
 
 ## Navigation
 At the start of every session, read `.mex/ROUTER.md` before doing anything else.

--- a/templates/.tool-configs/CLAUDE.md
+++ b/templates/.tool-configs/CLAUDE.md
@@ -32,7 +32,11 @@ last_updated: [YYYY-MM-DD]
      - Build: `npm run build` -->
 
 ## After Every Task
-After completing any task: update `.mex/ROUTER.md` project state and any `.mex/` files that are now out of date. If no pattern existed for the task you just completed, create one in `.mex/patterns/`.
+After meaningful work, run GROW:
+- Ground: what changed in reality?
+- Record: update `.mex/ROUTER.md` and relevant `.mex/context/` files
+- Orient: create or update a `.mex/patterns/` runbook if this can recur
+- Write: bump `last_updated` on changed scaffold files and run `mex log` when rationale matters
 
 ## Navigation
 At the start of every session, read `.mex/ROUTER.md` before doing anything else.

--- a/templates/.tool-configs/copilot-instructions.md
+++ b/templates/.tool-configs/copilot-instructions.md
@@ -32,7 +32,11 @@ last_updated: [YYYY-MM-DD]
      - Build: `npm run build` -->
 
 ## After Every Task
-After completing any task: update `.mex/ROUTER.md` project state and any `.mex/` files that are now out of date. If no pattern existed for the task you just completed, create one in `.mex/patterns/`.
+After meaningful work, run GROW:
+- Ground: what changed in reality?
+- Record: update `.mex/ROUTER.md` and relevant `.mex/context/` files
+- Orient: create or update a `.mex/patterns/` runbook if this can recur
+- Write: bump `last_updated` on changed scaffold files and run `mex log` when rationale matters
 
 ## Navigation
 At the start of every session, read `.mex/ROUTER.md` before doing anything else.

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -35,7 +35,13 @@ last_updated: [YYYY-MM-DD]
      - Build: `npm run build` -->
 
 ## Scaffold Growth
-After every task: if no pattern exists for the task type you just completed, create one. If a pattern or context file is now out of date, update it. The scaffold grows from real work, not just setup. See the GROW step in `ROUTER.md` for details.
+After meaningful work, run GROW:
+- Ground: what changed in reality?
+- Record: update `ROUTER.md` and relevant `context/` files
+- Orient: create or update a `patterns/` runbook if this can recur
+- Write: bump `last_updated` on changed scaffold files and run `mex log` when rationale matters
+
+The scaffold grows from real work, not just setup. See the GROW step in `ROUTER.md` for details.
 
 ## Navigation
 At the start of every session, read `ROUTER.md` before doing anything else.

--- a/templates/ROUTER.md
+++ b/templates/ROUTER.md
@@ -61,8 +61,8 @@ For every task, follow this loop:
 2. **BUILD** — Do the work. If a pattern exists, follow its Steps. If you are about to deviate from an established pattern, say so before writing any code — state the deviation and why.
 3. **VERIFY** — Load `context/conventions.md` and run the Verify Checklist item by item. State each item and whether the output passes. Do not summarise — enumerate explicitly.
 4. **DEBUG** — If verification fails or something breaks, check `patterns/INDEX.md` for a debug pattern. Follow it. Fix the issue and re-run VERIFY.
-5. **GROW** — After completing the task:
-   - If no pattern exists for this task type, create one in `patterns/` using the format in `patterns/README.md`. Add it to `patterns/INDEX.md`. Flag it: "Created `patterns/<name>.md` from this session."
-   - If a pattern exists but you deviated from it or discovered a new gotcha, update it with what you learned.
-   - If any `context/` file is now out of date because of this work, update it surgically — do not rewrite entire files.
-   - Update the "Current Project State" section above if the work was significant.
+5. **GROW** — After meaningful work, run this binary checklist:
+   - **Ground:** What changed in reality? Name the changed behavior, system, command, dependency, or workflow.
+   - **Record:** If project state changed, update the "Current Project State" section above. If documented facts changed, update the relevant `context/` file surgically.
+   - **Orient:** If this task can recur and no pattern exists, create one in `patterns/` using `patterns/README.md`, then add it to `patterns/INDEX.md`. If a pattern exists but you learned a gotcha, update it.
+   - **Write:** Bump `last_updated` in every scaffold file you changed. If the why matters, run `mex log --type decision "<what changed and why>"` or `mex log "<note>"`.

--- a/templates/agent-memory/AGENTS.md
+++ b/templates/agent-memory/AGENTS.md
@@ -1,0 +1,29 @@
+---
+name: agents
+description: Always-loaded operating contract for a persistent AI agent workspace.
+last_updated: [YYYY-MM-DD]
+---
+
+# [Agent / Workspace Name]
+
+## What This Is
+<!-- One sentence. What environment or agent does this scaffold describe? -->
+
+## Non-Negotiables
+<!-- 3-5 hard safety/operational rules the agent must never violate. -->
+
+## Commands
+<!-- Exact commands for health checks, service status, restart/recovery, and mex maintenance. -->
+
+## GROW
+After meaningful work:
+- Ground: what changed in reality?
+- Record: update `ROUTER.md` and relevant `context/` files
+- Orient: create/update a `patterns/` runbook if this can recur
+- Write: bump `last_updated` and run `mex log` when rationale matters
+
+## Heartbeat
+When invoked for a heartbeat, read `HEARTBEAT.md`. If all checks pass, respond with exactly `HEARTBEAT_OK`.
+
+## Navigation
+At the start of every normal session, read `ROUTER.md` before doing anything else.

--- a/templates/agent-memory/HEARTBEAT.md
+++ b/templates/agent-memory/HEARTBEAT.md
@@ -1,0 +1,23 @@
+---
+name: heartbeat
+description: Lightweight checks for scheduled persistent-agent heartbeat events.
+last_updated: [YYYY-MM-DD]
+---
+
+# Heartbeat
+
+Run these checks when the agent receives a heartbeat event.
+
+## Checks
+
+1. Run `mex heartbeat`.
+2. If it prints `HEARTBEAT_OK`, respond with exactly `HEARTBEAT_OK`.
+3. If it reports stale scaffold files, tell the user which files need review and suggest `mex sync`.
+4. If memory cleanup is due, review `memory/YYYY-MM-DD.md` files, promote durable insights to `MEMORY.md`, and update `memory/.last-cleanup.json`.
+5. Do not perform unrelated work during heartbeat.
+
+## Defaults
+
+- Context staleness threshold: 7 days unless `.mex/config.json` overrides `heartbeat.staleDays`.
+- Memory cleanup threshold: 7 days unless `.mex/config.json` overrides `heartbeat.memoryCleanupDays`.
+- Daily memory retention: 14 days unless `.mex/config.json` overrides `heartbeat.dailyMemoryRetentionDays`.

--- a/templates/agent-memory/ROUTER.md
+++ b/templates/agent-memory/ROUTER.md
@@ -1,0 +1,49 @@
+---
+name: router
+description: Session bootstrap and navigation hub for a persistent AI agent workspace.
+edges:
+  - target: context/architecture.md
+    condition: when working on services, infrastructure, automations, or system shape
+  - target: context/stack.md
+    condition: when checking tools, models, runtimes, versions, or hardware
+  - target: context/conventions.md
+    condition: when operating on the system or applying safety rules
+  - target: context/decisions.md
+    condition: when asking why something is configured a certain way
+  - target: context/setup.md
+    condition: when debugging, restarting, recovering, or inspecting services
+  - target: HEARTBEAT.md
+    condition: when handling a scheduled heartbeat
+last_updated: [YYYY-MM-DD]
+---
+
+# Session Bootstrap
+
+Read `AGENTS.md` first if it is not already loaded. Then read this file.
+
+## Current Operational State
+<!-- Active systems, known issues, current projects, and anything the agent must know before acting. -->
+
+## Routing Table
+
+| Task type | Load |
+|-----------|------|
+| System architecture or service topology | `context/architecture.md` |
+| Models, tools, hardware, versions, storage | `context/stack.md` |
+| Operational rules, naming, safety habits | `context/conventions.md` |
+| Why a decision was made | `context/decisions.md` |
+| Run, inspect, restart, recover | `context/setup.md` |
+| Scheduled heartbeat | `HEARTBEAT.md` |
+| Recurring task | `patterns/INDEX.md` |
+
+## Behavioural Contract
+
+1. **CONTEXT** — Load only the files relevant to the task.
+2. **ACT** — Do the requested work using the current operational state.
+3. **VERIFY** — Check the real system state before claiming success.
+4. **DEBUG** — If reality disagrees with the scaffold, trust reality and repair the scaffold.
+5. **GROW** — Ground, Record, Orient, Write:
+   - Ground: name what changed in reality.
+   - Record: update current truth in `ROUTER.md` or `context/`.
+   - Orient: create/update a `patterns/` runbook for recurring work.
+   - Write: bump `last_updated` and run `mex log` for decisions, risks, todos, or useful notes.

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -158,6 +158,39 @@ describe("findConfig — stalenessThresholds", () => {
   });
 });
 
+describe("findConfig — watch and heartbeat config", () => {
+  function setupConfig(config: unknown): void {
+    mkdirSync(join(tmpDir, ".git"));
+    const mexPath = join(tmpDir, ".mex");
+    mkdirSync(mexPath);
+    writeFileSync(join(mexPath, "ROUTER.md"), "");
+    writeFileSync(join(mexPath, "config.json"), JSON.stringify(config));
+  }
+
+  it("loads watch interval from config.json", () => {
+    setupConfig({ watch: { intervalMinutes: 45 } });
+    const config = findConfig(tmpDir);
+    expect(config.watch).toEqual({ intervalMinutes: 45 });
+  });
+
+  it("loads heartbeat thresholds from config.json", () => {
+    setupConfig({ heartbeat: { staleDays: 5, memoryCleanupDays: 8, dailyMemoryRetentionDays: 21 } });
+    const config = findConfig(tmpDir);
+    expect(config.heartbeat).toEqual({
+      staleDays: 5,
+      memoryCleanupDays: 8,
+      dailyMemoryRetentionDays: 21,
+    });
+  });
+
+  it("ignores non-positive watch and heartbeat values", () => {
+    setupConfig({ watch: { intervalMinutes: 0 }, heartbeat: { staleDays: -1 } });
+    const config = findConfig(tmpDir);
+    expect(config.watch).toBeUndefined();
+    expect(config.heartbeat).toBeUndefined();
+  });
+});
+
 describe("saveAiTools", () => {
   it("creates config.json with aiTools", () => {
     const mexPath = join(tmpDir, ".mex");

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { runLog, readEvents, runTimeline } from "../src/events.js";
+import type { MexConfig } from "../src/types.js";
+
+let tmpDir: string;
+let config: MexConfig;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "mex-events-"));
+  mkdirSync(join(tmpDir, ".mex"), { recursive: true });
+  config = { projectRoot: tmpDir, scaffoldRoot: join(tmpDir, ".mex"), aiTools: [] };
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe("events", () => {
+  it("appends log entries as JSONL", async () => {
+    await runLog(config, "captured a decision", { kind: "decision", files: ["ROUTER.md"] });
+    const raw = readFileSync(join(tmpDir, ".mex/events/decisions.jsonl"), "utf-8").trim();
+    const entry = JSON.parse(raw);
+    expect(entry).toMatchObject({
+      kind: "decision",
+      message: "captured a decision",
+      files: ["ROUTER.md"],
+    });
+  });
+
+  it("reads valid events and skips malformed lines", () => {
+    mkdirSync(join(tmpDir, ".mex/events"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, ".mex/events/decisions.jsonl"),
+      `${JSON.stringify({ timestamp: "2026-05-14T00:00:00.000Z", kind: "note", message: "ok", files: [] })}\nnot-json\n`,
+    );
+    expect(readEvents(config)).toHaveLength(1);
+  });
+
+  it("timeline can emit JSON", async () => {
+    await runLog(config, "hello", {});
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await runTimeline(config, { json: true });
+    expect(spy.mock.calls.at(-1)?.[0]).toContain('"events"');
+  });
+});

--- a/test/heartbeat.test.ts
+++ b/test/heartbeat.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { checkHeartbeat } from "../src/heartbeat.js";
+import type { MexConfig } from "../src/types.js";
+
+let tmpDir: string;
+let config: MexConfig;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "mex-heartbeat-"));
+  mkdirSync(join(tmpDir, ".mex/context"), { recursive: true });
+  writeFileSync(join(tmpDir, ".mex/ROUTER.md"), frontmatter("router", "2026-05-12"));
+  config = {
+    projectRoot: tmpDir,
+    scaffoldRoot: join(tmpDir, ".mex"),
+    aiTools: [],
+    heartbeat: { staleDays: 7, memoryCleanupDays: 7, dailyMemoryRetentionDays: 14 },
+  };
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("heartbeat", () => {
+  it("returns ok when files are fresh and memory cleanup is not configured", () => {
+    const result = checkHeartbeat(config, new Date("2026-05-14T00:00:00Z"));
+    expect(result.ok).toBe(true);
+    expect(result.staleFiles).toEqual([]);
+  });
+
+  it("flags files with stale last_updated frontmatter", () => {
+    writeFileSync(join(tmpDir, ".mex/context/architecture.md"), frontmatter("architecture", "2026-05-01"));
+    const result = checkHeartbeat(config, new Date("2026-05-14T00:00:00Z"));
+    expect(result.ok).toBe(false);
+    expect(result.staleFiles.map((f) => f.file)).toContain("context/architecture.md");
+  });
+
+  it("detects due memory cleanup and old daily memory files", () => {
+    mkdirSync(join(tmpDir, "memory"), { recursive: true });
+    writeFileSync(join(tmpDir, "memory/.last-cleanup.json"), JSON.stringify({ lastCleanup: "2026-05-01T00:00:00Z" }));
+    writeFileSync(join(tmpDir, "memory/2026-04-20.md"), "# old");
+    const result = checkHeartbeat(config, new Date("2026-05-14T00:00:00Z"));
+    expect(result.memoryCleanupDue).toBe(true);
+    expect(result.oldDailyMemoryFiles).toEqual(["memory/2026-04-20.md"]);
+  });
+});
+
+function frontmatter(name: string, lastUpdated: string): string {
+  return `---\nname: ${name}\nlast_updated: ${lastUpdated}\n---\n\n# ${name}\n`;
+}

--- a/test/staleness.test.ts
+++ b/test/staleness.test.ts
@@ -7,7 +7,7 @@ vi.mock("../src/git.js", () => ({
 }));
 
 const { daysSinceLastChange, commitsSinceLastChange } = await import("../src/git.js");
-const { checkStaleness, DEFAULT_STALENESS_THRESHOLDS } = await import("../src/drift/checkers/staleness.js");
+const { checkStaleness, DEFAULT_STALENESS_THRESHOLDS, daysSinceFrontmatterDate } = await import("../src/drift/checkers/staleness.js");
 
 const asMock = <T extends (...args: unknown[]) => unknown>(fn: T) =>
   fn as unknown as ReturnType<typeof vi.fn>;
@@ -116,5 +116,33 @@ describe("checkStaleness — custom thresholds", () => {
       errorCommits: 500,
     });
     expect(issues).toEqual([]);
+  });
+});
+
+describe("checkStaleness — last_updated frontmatter", () => {
+  it("ignores missing or placeholder last_updated values", () => {
+    const now = new Date("2026-05-14T12:00:00Z");
+    expect(daysSinceFrontmatterDate(undefined, now)).toBeNull();
+    expect(daysSinceFrontmatterDate("[YYYY-MM-DD]", now)).toBeNull();
+  });
+
+  it("computes days since a concrete frontmatter date", () => {
+    const now = new Date("2026-05-14T12:00:00Z");
+    expect(daysSinceFrontmatterDate("2026-05-07", now)).toBe(7);
+  });
+
+  it("adds last_updated staleness to the combined issue", async () => {
+    asMock(daysSinceLastChange).mockResolvedValue(0);
+    asMock(commitsSinceLastChange).mockResolvedValue(0);
+
+    const issues = await checkStaleness("a.md", "a.md", "/tmp/repo", {
+      warnDays: 7,
+      errorDays: 30,
+      warnCommits: 999,
+      errorCommits: 9999,
+    }, { lastUpdated: "2020-01-01" });
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toContain("last_updated");
   });
 });

--- a/test/tui.test.ts
+++ b/test/tui.test.ts
@@ -1,0 +1,85 @@
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { render } from "ink-testing-library";
+import { ErrorScreen, HeartbeatPanel, Summary, TimelinePanel, type DashboardData } from "../src/tui.js";
+
+const h = React.createElement;
+
+function data(overrides: Partial<DashboardData> = {}): DashboardData {
+  return {
+    report: {
+      score: 100,
+      issues: [],
+      filesChecked: 3,
+      timestamp: "2026-05-14T00:00:00.000Z",
+    },
+    heartbeat: {
+      ok: true,
+      staleFiles: [],
+      memoryCleanupDue: false,
+      oldDailyMemoryFiles: [],
+    },
+    events: [],
+    ...overrides,
+  };
+}
+
+describe("TUI components", () => {
+  it("renders healthy dashboard summary", () => {
+    const app = render(h(Summary, { data: data(), notice: null }));
+    expect(app.lastFrame()).toContain("Drift 100/100");
+    expect(app.lastFrame()).toContain("Heartbeat OK");
+  });
+
+  it("renders drift warnings and errors in summary", () => {
+    const app = render(h(Summary, {
+      data: data({
+        report: {
+          score: 77,
+          issues: [
+            { code: "MISSING_PATH", severity: "error", file: "ROUTER.md", line: null, message: "missing" },
+            { code: "STALE_FILE", severity: "warning", file: "context/stack.md", line: null, message: "stale" },
+          ],
+          filesChecked: 4,
+          timestamp: "2026-05-14T00:00:00.000Z",
+        },
+      }),
+      notice: null,
+    }));
+    expect(app.lastFrame()).toContain("1 errors, 1 warnings");
+  });
+
+  it("renders heartbeat stale files", () => {
+    const app = render(h(HeartbeatPanel, {
+      data: data({
+        heartbeat: {
+          ok: false,
+          staleFiles: [{ file: "context/architecture.md", days: 12 }],
+          memoryCleanupDue: false,
+          oldDailyMemoryFiles: [],
+        },
+      }),
+    }));
+    expect(app.lastFrame()).toContain("context/architecture.md");
+    expect(app.lastFrame()).toContain("12 days");
+  });
+
+  it("renders timeline entries in provided order", () => {
+    const app = render(h(TimelinePanel, {
+      data: data({
+        events: [
+          { timestamp: "2026-05-14T00:00:00.000Z", kind: "decision", message: "newer", files: [], cwd: "." },
+          { timestamp: "2026-05-01T00:00:00.000Z", kind: "note", message: "older", files: [], cwd: "." },
+        ],
+      }),
+    }));
+    const frame = app.lastFrame() ?? "";
+    expect(frame.indexOf("newer")).toBeLessThan(frame.indexOf("older"));
+  });
+
+  it("renders no-scaffold error screen", () => {
+    const app = render(h(ErrorScreen, { message: "No .mex/ scaffold found. Run: mex setup" }));
+    expect(app.lastFrame()).toContain("could not start");
+    expect(app.lastFrame()).toContain("mex setup");
+  });
+});

--- a/test/tui.test.ts
+++ b/test/tui.test.ts
@@ -1,7 +1,15 @@
 import React from "react";
 import { describe, expect, it } from "vitest";
 import { render } from "ink-testing-library";
-import { ErrorScreen, HeartbeatPanel, Summary, TimelinePanel, type DashboardData } from "../src/tui.js";
+import {
+  ErrorScreen,
+  HeartbeatPanel,
+  Summary,
+  TimelinePanel,
+  eventActivityBars,
+  progressBar,
+  type DashboardData,
+} from "../src/tui.js";
 
 const h = React.createElement;
 
@@ -27,8 +35,10 @@ function data(overrides: Partial<DashboardData> = {}): DashboardData {
 describe("TUI components", () => {
   it("renders healthy dashboard summary", () => {
     const app = render(h(Summary, { data: data(), notice: null }));
-    expect(app.lastFrame()).toContain("Drift 100/100");
+    expect(app.lastFrame()).toContain("Drift");
+    expect(app.lastFrame()).toContain("100/100");
     expect(app.lastFrame()).toContain("Heartbeat OK");
+    expect(app.lastFrame()).toContain("████");
   });
 
   it("renders drift warnings and errors in summary", () => {
@@ -46,7 +56,7 @@ describe("TUI components", () => {
       }),
       notice: null,
     }));
-    expect(app.lastFrame()).toContain("1 errors, 1 warnings");
+    expect(app.lastFrame()).toContain("1 errors · 1 warnings");
   });
 
   it("renders heartbeat stale files", () => {
@@ -75,6 +85,25 @@ describe("TUI components", () => {
     }));
     const frame = app.lastFrame() ?? "";
     expect(frame.indexOf("newer")).toBeLessThan(frame.indexOf("older"));
+  });
+
+  it("renders timeline empty state", () => {
+    const app = render(h(TimelinePanel, { data: data() }));
+    expect(app.lastFrame()).toContain("No events yet");
+  });
+
+  it("builds progress bars for status rows", () => {
+    expect(progressBar(50, 10)).toBe("█████░░░░░");
+    expect(progressBar(200, 4)).toBe("████");
+  });
+
+  it("builds event activity bars oldest to newest", () => {
+    const bars = eventActivityBars([
+      { timestamp: "2026-05-12T10:00:00.000Z", kind: "decision", message: "one", files: [], cwd: "." },
+      { timestamp: "2026-05-14T10:00:00.000Z", kind: "note", message: "two", files: [], cwd: "." },
+      { timestamp: "2026-05-14T11:00:00.000Z", kind: "risk", message: "three", files: [], cwd: "." },
+    ], 3, new Date("2026-05-14T12:00:00.000Z"));
+    expect(bars).toBe("▅▁█");
   });
 
   it("renders no-scaffold error screen", () => {

--- a/test/tui.test.ts
+++ b/test/tui.test.ts
@@ -56,7 +56,7 @@ describe("TUI components", () => {
       }),
       notice: null,
     }));
-    expect(app.lastFrame()).toContain("1 errors · 1 warnings");
+    expect(app.lastFrame()).toContain("1 error · 1 warning");
   });
 
   it("renders heartbeat stale files", () => {


### PR DESCRIPTION
## Summary

Prepares the mex v0.3 operational-memory release on top of the stable v0.2 architecture.

This includes:
- agent-memory setup mode for persistent-agent / homelab / OpenClaw-style workspaces
- heartbeat checks and `mex watch --interval`
- append-only event log with `mex log` and `mex timeline`
- `mex doctor`, shell completions, and improved check output
- Ink TUI dashboard shipped through bare `mex` and `mex tui`
- npm release prep for `promexeus@0.3.5`
- copy-ready GitHub release notes in `RELEASE_NOTES.md`

## Release Notes

Full release notes are in `RELEASE_NOTES.md` and cover:
- agent memory layer
- heartbeat / scheduled checks
- TUI dashboard
- OpenClaw and persistent-agent usage
- upgrade instructions
- compatibility and deferred architecture work

## Verification

- `npm run typecheck`
- `npm test` — 138 passing
- `npm run build`
- `node dist/cli.js --version` → `0.3.5`
- `npm --cache /private/tmp/mex-npm-cache pack --dry-run` → `promexeus-0.3.5.tgz`
- `git diff --check`
- manual TTY smoke for `node dist/cli.js tui`