### PR TITLE
feat: compatibility contract, trace field, git-install ergonomics

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,0 +1,141 @@
+# Compatibility & versioning
+
+This document defines `mex-agent`'s public contract: what's stable, what isn't,
+and what counts as a breaking change. It is intended for embedders — tools that
+depend on `mex-agent` as a library — and for `mex-agent` maintainers when
+shipping new versions.
+
+If you only use the `mex` CLI, most of this still applies, but CLI flags
+themselves are best-effort (see [CLI surface](#cli-surface) below).
+
+## The public API
+
+The only public surface is what's exported from the package entry point:
+
+```ts
+import { /* … */ } from "mex-agent";
+```
+
+Concretely, that's everything re-exported from
+[`src/index.ts`](./src/index.ts):
+
+- **Functions** — `findConfig`, `createConfig`, `appendEvent`, `readEvents`,
+  `eventLogPath`, `runDriftCheck`, `parseFrontmatter`, `checkHeartbeat`,
+  `runHeartbeat`.
+- **Runtime constants** — `EVENT_KINDS`, `DEFAULT_STALENESS_THRESHOLDS`,
+  `DEFAULT_SCAFFOLD_PATTERNS`, `DEFAULT_HEARTBEAT_PATTERNS`.
+- **Types** — `MexConfig`, `CreateConfigInput`, `EventEntry`, `EventKind`,
+  `LogOpts`, `DriftReport`, `DriftIssue`, `RunDriftCheckOpts`,
+  `HeartbeatResult`, `HeartbeatOpts`, `CheckHeartbeatOpts`,
+  `StalenessThresholds`, `WatchConfig`, `HeartbeatConfig`, `AiTool`,
+  `IssueCode`, `Severity`, `ScaffoldFrontmatter`, `FrontmatterEdge`, `Claim`,
+  `ClaimKind`.
+
+The CI smoke test at [`test/public-api.test.ts`](./test/public-api.test.ts)
+asserts the existence and basic shape of these exports. Any change that breaks
+that test is a breaking change.
+
+## What is NOT public
+
+Everything else. Specifically:
+
+- All internal modules — `src/cli.ts`, `src/sync/`, `src/scanner/`,
+  `src/setup/`, `src/tui.ts`, `src/watch.ts`, `src/doctor.ts`, and any other
+  path not re-exported from `src/index.ts`.
+- Deep imports such as `mex-agent/dist/internal.js` — the `exports` field in
+  `package.json` blocks these, and they may break without notice.
+- The on-disk format of internal files such as the scaffold `config.json`. Use
+  the documented helpers to read and write them.
+
+## Semver policy
+
+`mex-agent` follows [semver](https://semver.org/) with this interpretation:
+
+| Change                                                | Type  |
+| ----------------------------------------------------- | ----- |
+| Adding a new export                                   | minor |
+| Adding an optional parameter to a public function     | minor |
+| Adding an optional field to a public interface        | minor |
+| Widening accepted input types                         | minor |
+| Bug fix preserving documented behaviour               | patch |
+| Internal refactor not visible from outside            | patch |
+| Removing a public export                              | major |
+| Renaming a public export                              | major |
+| Changing a function signature (required parameters)   | major |
+| Narrowing a return type or required field             | major |
+| Removing a field from a public interface              | major |
+
+While the package is on `0.x` (pre-1.0), breaking changes may ship in minor
+versions, but they will still be flagged as breaking — surfaced in the
+changelog, with a deprecation note where possible and migration guidance in the
+PR description.
+
+## "Soft" parts of the public API
+
+Two exports are public *in name* but not in *contents*:
+
+- **`DEFAULT_SCAFFOLD_PATTERNS`** — the constant continues to exist and to be
+  exported, but new entries may be added in any minor version. Embedders that
+  need exact behaviour should pass `scaffoldPatterns` explicitly to
+  `runDriftCheck`.
+- **`DEFAULT_HEARTBEAT_PATTERNS`** — same policy. Pass `scaffoldPatterns`
+  explicitly to `checkHeartbeat` / `runHeartbeat` if exact behaviour matters.
+
+These constants are exported so embedders can extend the defaults
+(`[...DEFAULT_SCAFFOLD_PATTERNS, "traces/**/*.md"]`) rather than re-typing the
+list. They are not a contract on the list's contents.
+
+## Scaffold-directory ownership
+
+Inside the `.mex/` scaffold directory, some paths are owned by `mex-agent`
+itself, and some are reserved for embedders.
+
+### Owned by mex (mex writes, scans, or manages these)
+
+- `ROUTER.md`, `AGENTS.md`, `SETUP.md`, `SYNC.md` — top-level scaffold files.
+- `context/*.md` — context documents (scanned by drift checkers).
+- `patterns/*.md` — pattern documents (scanned by drift checkers).
+- `events/decisions.jsonl` — append-only event log.
+- `config.json` — persisted scaffold configuration.
+
+Embedders should not write to these paths.
+
+### Reserved for embedders
+
+These paths are not scanned by default checkers and `mex-agent` will not write
+to them. Embedders may use them freely:
+
+- `.mex/traces/**` — long-form decision traces.
+- `.mex/failures/**` — failure / postmortem records.
+
+Other paths under `.mex/` are unclaimed. If you're an embedder and need a new
+namespace, open an issue first — `mex-agent` may add features later that
+conflict otherwise.
+
+## CLI surface
+
+The `mex` CLI ships in the package, but its flag and subcommand surface is
+**best-effort, not contract-bound**. The CLI is a thin wrapper over the
+programmatic API; embedders should consume the programmatic API directly
+rather than shell out.
+
+If you need a CLI flag to remain stable, file an issue requesting it be
+promoted to the public contract.
+
+## Deprecation policy
+
+When a public export is going to be removed:
+
+1. It is marked `@deprecated` in JSDoc and noted in the changelog.
+2. It remains functional for **at least one minor version** with the
+   deprecation warning in place.
+3. The next major version removes it.
+
+Concrete example: if `foo` is deprecated in 0.5.0, it still works in 0.5.x and
+0.6.x. It may be removed in 0.7.0 or 1.0.0.
+
+## Reporting compatibility issues
+
+If you find behaviour that diverges from this document — an undocumented
+breaking change, an unclear case, or a contract you need that isn't covered —
+open an issue at <https://github.com/theDakshJaitly/mex/issues>.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "dist",
     "templates",
     "LICENSE",
-    "README.md"
+    "README.md",
+    "COMPATIBILITY.md"
   ],
   "keywords": [
     "ai",
@@ -47,7 +48,8 @@
     "dev": "tsup --watch",
     "test": "vitest run",
     "test:watch": "vitest",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "prepare": "npm run build"
   },
   "dependencies": {
     "chalk": "^5.4.1",

--- a/src/events.ts
+++ b/src/events.ts
@@ -15,11 +15,20 @@ export interface EventEntry {
   message: string;
   files: string[];
   cwd: string;
+  /** Optional pointer to a long-form trace document for this event. Free-form
+   *  string — typically a path under `.mex/traces/` (e.g.
+   *  `.mex/traces/2026-05-15-jwt.md`) but no format is enforced. Intended for
+   *  embedders that capture richer context than the short `message` field
+   *  can hold. Omitted on entries that don't reference a trace. */
+  trace?: string;
 }
 
 export interface LogOpts {
   kind?: string;
   files?: string[];
+  /** Optional pointer to a long-form trace document — persisted as
+   *  `EventEntry.trace`. See that field for the contract. */
+  trace?: string;
 }
 
 export interface TimelineOpts {
@@ -51,6 +60,7 @@ export function appendEvent(config: MexConfig, message: string, opts: LogOpts = 
     files,
     cwd: relative(config.projectRoot, process.cwd()) || ".",
   };
+  if (opts.trace !== undefined) entry.trace = opts.trace;
   const file = eventLogPath(config);
   mkdirSync(dirname(file), { recursive: true });
   appendFileSync(file, JSON.stringify(entry) + "\n");
@@ -99,13 +109,15 @@ export function readEvents(config: MexConfig): EventEntry[] {
         typeof raw.message === "string" &&
         Array.isArray(raw.files)
       ) {
-        entries.push({
+        const entry: EventEntry = {
           timestamp: raw.timestamp,
           kind: raw.kind,
           message: raw.message,
           files: raw.files.filter((f: unknown): f is string => typeof f === "string"),
           cwd: typeof raw.cwd === "string" ? raw.cwd : ".",
-        });
+        };
+        if (typeof raw.trace === "string") entry.trace = raw.trace;
+        entries.push(entry);
       }
     } catch {
       // Ignore malformed historical lines; timeline should remain usable.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,8 @@
  * Public API for `mex-agent`.
  *
  * Everything re-exported from this file is part of the package's compatibility
- * contract — removing or reshaping any of these is a breaking change.
+ * contract. See COMPATIBILITY.md at the repo root for the versioning policy
+ * and what counts as a breaking change.
  *
  * Internal modules (`src/cli.ts`, `src/sync/`, `src/scanner/`, `src/setup/`,
  * `src/tui.ts`, `src/watch.ts`, `src/doctor.ts`, etc.) are NOT part of the

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ export {
   eventLogPath,
   EVENT_KINDS,
 } from "./events.js";
-export type { EventEntry, EventKind } from "./events.js";
+export type { EventEntry, EventKind, LogOpts } from "./events.js";
 
 // ── Drift detection ──────────────────────────────────────────────────────────
 export {

--- a/test/public-api.test.ts
+++ b/test/public-api.test.ts
@@ -3,8 +3,11 @@
  *
  * This file imports ONLY from src/index.ts — the same surface that
  * package.json's `exports` field publishes. Its job is to fail when someone
- * accidentally renames, removes, or reshapes a public-facing export. If you
- * need to change something this test asserts, that's a breaking change.
+ * accidentally renames, removes, or reshapes a public-facing export.
+ *
+ * See COMPATIBILITY.md at the repo root for the contract this test enforces.
+ * Any change here is a breaking change — bump the major version and update
+ * the doc.
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
@@ -58,7 +61,7 @@ afterEach(() => {
 });
 
 describe("public API — function exports", () => {
-  it("exports the functions T-Rex (and other embedders) depend on", () => {
+  it("exports the functions embedders depend on", () => {
     expect(typeof appendEvent).toBe("function");
     expect(typeof readEvents).toBe("function");
     expect(typeof eventLogPath).toBe("function");
@@ -149,6 +152,28 @@ describe("public API — appendEvent / readEvents round-trip", () => {
       appendEvent(config, `event for ${k}`, { kind: k });
     }
     expect(readEvents(config)).toHaveLength(EVENT_KINDS.length);
+  });
+
+  it("persists and reads back the optional trace field", () => {
+    const tracePath = ".mex/traces/2026-05-15-jwt.md";
+    const written = appendEvent(config, "Use JWT over sessions", {
+      kind: "decision",
+      trace: tracePath,
+    });
+    expect(written.trace).toBe(tracePath);
+
+    const events = readEvents(config);
+    expect(events).toHaveLength(1);
+    expect(events[0].trace).toBe(tracePath);
+  });
+
+  it("omits the trace field when not provided", () => {
+    const written = appendEvent(config, "Plain note", { kind: "note" });
+    expect(written.trace).toBeUndefined();
+
+    const events = readEvents(config);
+    expect(events).toHaveLength(1);
+    expect(events[0].trace).toBeUndefined();
   });
 });
 

--- a/test/public-api.test.ts
+++ b/test/public-api.test.ts
@@ -36,6 +36,7 @@ import {
   type MexConfig,
   type EventEntry,
   type EventKind,
+  type LogOpts,
   type DriftReport,
   type HeartbeatResult,
   type CreateConfigInput,
@@ -156,10 +157,11 @@ describe("public API — appendEvent / readEvents round-trip", () => {
 
   it("persists and reads back the optional trace field", () => {
     const tracePath = ".mex/traces/2026-05-15-jwt.md";
-    const written = appendEvent(config, "Use JWT over sessions", {
+    const opts: LogOpts = {
       kind: "decision",
       trace: tracePath,
-    });
+    };
+    const written = appendEvent(config, "Use JWT over sessions", opts);
     expect(written.trace).toBe(tracePath);
 
     const events = readEvents(config);


### PR DESCRIPTION
 ## What

  Three changes that round out the public-API work from #44:

  - **`COMPATIBILITY.md`** at the repo root — written contract for embedders.       
    Defines the public surface (everything re-exported from `src/index.ts`),        
    semver interpretation (additive minors, breaking majors), the "soft" exports    
    whose names are stable but contents aren't (`DEFAULT_SCAFFOLD_PATTERNS`,        
    `DEFAULT_HEARTBEAT_PATTERNS`), scaffold-directory ownership (which paths        
    inside `.mex/` mex owns vs. reserves for embedders, including `.mex/traces/`    
    and `.mex/failures/`), the CLI-flag policy, and the deprecation window.

  - **`EventEntry.trace?: string`** — optional field on event-log entries,
    pointing at a long-form trace document (free-form string, typically a path      
    under `.mex/traces/`). Wired through `appendEvent` (accepts `trace` in
    `LogOpts`) and `readEvents` (preserved when present, ignored when absent —      
    so old log lines parse unchanged). Lets embedders that need richer context      
    per event link to it without forking the event format.

  - **`"prepare": "npm run build"`** in `package.json` — so
    `npm install github:<fork>/mex` builds `dist/` automatically inside the
    consumer's `node_modules`. Without this, git-URL installs resolve but ship      
    no `dist/`, and the consumer has to `cd node_modules/mex-agent && npm run build`
    manually. `COMPATIBILITY.md` is also added to the `files` array so it ships     
    with published packages.

  Also re-adds the `COMPATIBILITY.md` JSDoc references in `src/index.ts` and        
  `test/public-api.test.ts` that were stripped during the review of #44 — the       
  doc didn't exist then; now it does.

  ## Why

  - The compatibility contract turns `mex-agent` into something embedders can       
    depend on without pinning exact versions or guessing at stability. The
    scaffold-ownership section in particular prevents future namespace
    collisions between mex and tools building on top of it.
  - The `trace` field is the minimum data-model change needed for tools that        
    capture longer-form decision context to coexist with mex's event log.
    Strictly additive — `trace` is optional, defaults to absent, and old log        
    lines round-trip unchanged.
  - `prepare` removes the manual `npm run build` step for anyone installing
    from a fork branch, which is the workflow embedders use during development      
    before a release is on npm.

  ## Type of change

  - [ ] Bug fix
  - [x] New feature
  - [ ] Refactor
  - [x] Docs
  - [x] CI/Tooling

  ## How to test

  1. `npm run typecheck` — clean.
  2. `npm test` — 155 tests total; 2 new trace round-trip tests in
     `test/public-api.test.ts` pass. Pre-existing Windows path-separator
     failures in `test/heartbeat.test.ts:38` and `test/scanner.test.ts:56` are      
     unrelated to this PR (still failing on `main`, pass on Linux CI).
  3. `npm run build` — `dist/index.d.ts` grows slightly to include the new
     `trace?: string` field on `EventEntry` and `LogOpts`.
  4. Round-trip check: append an event with `appendEvent(config, "msg", { kind:   "decision", trace: ".mex/traces/foo.md" })`,
     then `readEvents(config)` — the trace string should come back. Append
     another event without `trace`; reading it back, `trace` should be
     `undefined`.
  ## Checklist

  - [x] Tests pass (`npm test`) — 153 green; 2 pre-existing Windows failures        
  unrelated.
  - [x] No breaking changes — all additions are additive: new file, new optional    
  field, new script entry, new docs.
  - [x] Tested locally — typecheck, full test suite, and build all verified on      
  Windows.