### PR TITLE
fix(cli): read version from package metadata

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,22 @@
 import chalk from "chalk";
 import { Command, InvalidArgumentError } from "commander";
+import { readFileSync } from "node:fs";
 import { findConfig } from "./config.js";
 import { reportConsole, reportQuiet, reportJSON, reportVerbose } from "./reporter.js";
+
+function readPackageVersion(): string {
+  const packageJson = JSON.parse(
+    readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+  ) as { version?: unknown };
+
+  if (typeof packageJson.version !== "string" || packageJson.version.length === 0) {
+    throw new Error("package.json is missing a valid version field.");
+  }
+
+  return packageJson.version;
+}
+
+export const CLI_VERSION = readPackageVersion();
 
 export function parseIntArg(raw: string): number {
   const n = Number.parseInt(raw, 10);
@@ -29,7 +44,7 @@ async function runTuiCommand(): Promise<void> {
 program
   .name("mex")
   .description("CLI engine for mex scaffold — drift detection, pre-analysis, and targeted sync")
-  .version("0.3.5")
+  .version(CLI_VERSION)
   .showHelpAfterError()
   .action(async () => {
     await runTuiCommand();

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from "vitest";
 import { Command, InvalidArgumentError } from "commander";
+import { readFileSync } from "node:fs";
 import { runLog, runTimeline } from "../src/events.js";
 import type { MexConfig } from "../src/types.js";
 
@@ -10,6 +11,9 @@ vi.mock("../src/events.js", () => ({
 
 let parseIntArg: typeof import("../src/cli.js").parseIntArg;
 let parsePositiveIntArg: typeof import("../src/cli.js").parsePositiveIntArg;
+let CLI_VERSION: typeof import("../src/cli.js").CLI_VERSION;
+
+const packageVersion = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")).version;
 
 const config: MexConfig = {
   projectRoot: process.cwd(),
@@ -22,7 +26,7 @@ beforeAll(async () => {
   const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
   process.argv = ["node", "mex", "completion", "bash"];
   try {
-    ({ parseIntArg, parsePositiveIntArg } = await import("../src/cli.js"));
+    ({ parseIntArg, parsePositiveIntArg, CLI_VERSION } = await import("../src/cli.js"));
   } finally {
     process.argv = originalArgv;
     logSpy.mockRestore();
@@ -84,6 +88,23 @@ function buildProgram(): Command {
 }
 
 describe("CLI argument parsers", () => {
+  it("reports the package.json version for --version", () => {
+    let output = "";
+    const program = new Command()
+      .name("mex")
+      .version(CLI_VERSION)
+      .exitOverride()
+      .configureOutput({
+        writeOut: (value) => {
+          output += value;
+        },
+        writeErr: () => {},
+      });
+
+    expect(() => program.parse(["node", "mex", "--version"])).toThrow();
+    expect(output.trim()).toBe(packageVersion);
+  });
+
   it("parses non-negative integers", () => {
     expect(parseIntArg("0")).toBe(0);
     expect(parseIntArg("12")).toBe(12);


### PR DESCRIPTION
## Summary
- Read the CLI version from the root package.json instead of hard-coding it in src/cli.ts.
- Export CLI_VERSION and use it for commander --version wiring.
- Add a regression test that verifies the --version wiring uses package.json's version field.

Closes #48.

## Validation
- `npm run typecheck`
- `npm test -- test/cli.test.ts`
- `npm run build`
- `node dist/cli.js --version` -> `0.5.0`

Note: `npm test` currently has two Windows path-separator failures outside this change:
- `test/scanner.test.ts > scanEntryPoints > finds src/index.ts as main entry`
- `test/heartbeat.test.ts > heartbeat > flags files with stale last_updated frontmatter`

The new CLI version regression test passes in `test/cli.test.ts`.