### PR TITLE
docs: add Windows / WSL note to README install section (#10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ Install globally later at any time:
 npm install -g mex-agent
 ```
 
+### Windows
+
+The recommended `npx mex-agent setup` flow runs in any terminal (Command Prompt, PowerShell, or WSL) and does not need bash, so most Windows users do not have to think about this section.
+
+If you previously installed via the legacy `setup.sh` script, do not mix environments. Building inside WSL and then running the CLI from a native Windows terminal causes "module not found" errors because `node_modules` and path resolution differ between the two filesystems. Run install, build, and CLI commands inside the same environment: either entirely in WSL / Git Bash, or entirely in native Windows via `npx mex-agent`.
+
+See [issue #10](https://github.com/theDakshJaitly/mex/issues/10) for context.
+
 ## How It Works
 
 ![mex context routing flow](docs/diagrams/context-routing.svg)

--- a/README.md
+++ b/README.md
@@ -90,7 +90,9 @@ npm install -g mex-agent
 
 The recommended `npx mex-agent setup` flow runs in any terminal (Command Prompt, PowerShell, or WSL) and does not need bash, so most Windows users do not have to think about this section.
 
-If you previously installed via the legacy `setup.sh` script, do not mix environments. Building inside WSL and then running the CLI from a native Windows terminal causes "module not found" errors because `node_modules` and path resolution differ between the two filesystems. Run install, build, and CLI commands inside the same environment: either entirely in WSL / Git Bash, or entirely in native Windows via `npx mex-agent`.
+> **Windows users (legacy `setup.sh` flow):** Run all commands inside WSL or Git Bash. Do not mix environments.
+
+If you previously installed via the legacy `setup.sh` script, building inside WSL and then running the CLI from a native Windows terminal causes "module not found" errors because `node_modules` and path resolution differ between the two filesystems. Run install, build, and CLI commands inside the same environment: either entirely in WSL / Git Bash, or entirely in native Windows via `npx mex-agent`.
 
 See [issue #10](https://github.com/theDakshJaitly/mex/issues/10) for context.
 


### PR DESCRIPTION
Carries forward the rebased version of #38 (by @mvanhorn) so it can merge cleanly.

## Summary

Refs #10 (first checkbox only — README Windows callout). The native Windows setup path and native CLI testing items remain; #69 is the PR that closes #10.

Adds a short `### Windows` subsection to the README's Quick Start section. It documents the mitigation the maintainer flagged in the issue thread: `npx mex-agent setup` works in any terminal and avoids the WSL/Windows path mismatch entirely. For users on the legacy `setup.sh` flow, a one-paragraph warning explains the "module not found" error and tells them to keep install/build/CLI inside one environment.

## Changes from #38

- Rebased onto current `main` (was 17 commits behind)
- Resolved README conflict: Windows subsection now sits after Quick Start, before How It Works
- Updated outdated `promexeus` references to `mex-agent` to match the current README

## Files changed

- `README.md` — adds an 8-line `### Windows` subsection after the global-install block and before `## How It Works`

## Test plan

- [x] No code changes
- [x] Existing install commands and headings unchanged
- [x] New section follows the README's existing tone (informal, direct)
- [x] Link to #10 for context

Supersedes #38 once merged.
