### PR TITLE
fix(path-checker): resolve workspace aliases and filter URLs (review fixes)

### DIFF
--- a/src/drift/checkers/path.ts
+++ b/src/drift/checkers/path.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { resolve } from "node:path";
 import { globSync } from "glob";
+import YAML from "yaml";
 import type { Claim, DriftIssue } from "../../types.js";
 
 const PLACEHOLDER_WORDS = /(?:^|[/_-])(?:new|example|your|sample|my|foo|bar|placeholder|template)(?:[/_.-]|$)/i;
@@ -10,7 +11,7 @@ const PLACEHOLDER_WORDS = /(?:^|[/_-])(?:new|example|your|sample|my|foo|bar|plac
 const SCOPED_PACKAGE = /^@([\w-]+)\/([\w-]+)(\/.*)?$/;
 
 /** URLs are not filesystem paths */
-const URL_PATTERN = /^https?:\/\//;
+const URL_PATTERN = /^(?:https?|ftp|file):\/\/|^\/\//;
 
 /** Check that all claimed paths exist on disk */
 export function checkPaths(
@@ -53,26 +54,12 @@ export function checkPaths(
 
 /**
  * Collect the `name` field from each workspace's package.json.
- * Works with any package manager (npm, yarn, pnpm, bun) since it reads
- * the standard `workspaces` field from the root manifest.
+ * Reads the root `workspaces` field (npm, yarn, bun) or falls back to
+ * `pnpm-workspace.yaml` when that field is absent (pnpm monorepos).
  */
 function collectWorkspaceNames(projectRoot: string): Set<string> {
   const names = new Set<string>();
-
-  const rootPkgPath = resolve(projectRoot, "package.json");
-  if (!existsSync(rootPkgPath)) return names;
-
-  let rootPkg: { workspaces?: string[] | { packages?: string[] } };
-  try {
-    rootPkg = JSON.parse(readFileSync(rootPkgPath, "utf-8"));
-  } catch {
-    return names;
-  }
-
-  // Normalize workspaces field (array or { packages: [...] })
-  const patterns: string[] = Array.isArray(rootPkg.workspaces)
-    ? rootPkg.workspaces
-    : rootPkg.workspaces?.packages ?? [];
+  const patterns = collectWorkspacePatterns(projectRoot);
 
   for (const pattern of patterns) {
     const dirs = globSync(pattern, {
@@ -92,6 +79,35 @@ function collectWorkspaceNames(projectRoot: string): Set<string> {
   }
 
   return names;
+}
+
+function collectWorkspacePatterns(projectRoot: string): string[] {
+  const rootPkgPath = resolve(projectRoot, "package.json");
+  if (existsSync(rootPkgPath)) {
+    try {
+      const rootPkg: { workspaces?: string[] | { packages?: string[] } } = JSON.parse(
+        readFileSync(rootPkgPath, "utf-8")
+      );
+      const patterns = Array.isArray(rootPkg.workspaces)
+        ? rootPkg.workspaces
+        : rootPkg.workspaces?.packages ?? [];
+      if (patterns.length > 0) return patterns;
+    } catch {
+      // Fall through to pnpm-workspace.yaml
+    }
+  }
+
+  const pnpmWorkspacePath = resolve(projectRoot, "pnpm-workspace.yaml");
+  if (!existsSync(pnpmWorkspacePath)) return [];
+
+  try {
+    const doc = YAML.parse(readFileSync(pnpmWorkspacePath, "utf-8")) as {
+      packages?: string[];
+    } | null;
+    return Array.isArray(doc?.packages) ? doc.packages : [];
+  } catch {
+    return [];
+  }
 }
 
 function pathExists(
@@ -122,7 +138,7 @@ function pathExists(
 
     // Try Node's module resolution first (works for installed npm packages)
     try {
-      const req = createRequire(resolve(projectRoot, "package.json"));
+      const req = createRequire(resolve(projectRoot, "noop.js"));
       req.resolve(`${pkgName}/package.json`);
       return true;
     } catch {

--- a/src/drift/checkers/path.ts
+++ b/src/drift/checkers/path.ts
@@ -1,9 +1,16 @@
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
 import { resolve } from "node:path";
 import { globSync } from "glob";
 import type { Claim, DriftIssue } from "../../types.js";
 
 const PLACEHOLDER_WORDS = /(?:^|[/_-])(?:new|example|your|sample|my|foo|bar|placeholder|template)(?:[/_.-]|$)/i;
+
+/** Scoped package pattern: @scope/name or @scope/name/sub/path */
+const SCOPED_PACKAGE = /^@([\w-]+)\/([\w-]+)(\/.*)?$/;
+
+/** URLs are not filesystem paths */
+const URL_PATTERN = /^https?:\/\//;
 
 /** Check that all claimed paths exist on disk */
 export function checkPaths(
@@ -16,8 +23,14 @@ export function checkPaths(
     (c) => c.kind === "path" && !c.negated
   );
 
+  // Collect workspace package names once for all claims
+  const workspaceNames = collectWorkspaceNames(projectRoot);
+
   for (const claim of pathClaims) {
-    if (pathExists(claim.value, projectRoot, scaffoldRoot)) continue;
+    // URLs are never filesystem paths
+    if (URL_PATTERN.test(claim.value)) continue;
+
+    if (pathExists(claim.value, projectRoot, scaffoldRoot, workspaceNames)) continue;
 
     // Downgrade to warning if: from a pattern file or path contains placeholder words.
     // Bare filenames that aren't found even after recursive search are genuinely missing.
@@ -38,7 +51,55 @@ export function checkPaths(
   return issues;
 }
 
-function pathExists(value: string, projectRoot: string, scaffoldRoot: string): boolean {
+/**
+ * Collect the `name` field from each workspace's package.json.
+ * Works with any package manager (npm, yarn, pnpm, bun) since it reads
+ * the standard `workspaces` field from the root manifest.
+ */
+function collectWorkspaceNames(projectRoot: string): Set<string> {
+  const names = new Set<string>();
+
+  const rootPkgPath = resolve(projectRoot, "package.json");
+  if (!existsSync(rootPkgPath)) return names;
+
+  let rootPkg: { workspaces?: string[] | { packages?: string[] } };
+  try {
+    rootPkg = JSON.parse(readFileSync(rootPkgPath, "utf-8"));
+  } catch {
+    return names;
+  }
+
+  // Normalize workspaces field (array or { packages: [...] })
+  const patterns: string[] = Array.isArray(rootPkg.workspaces)
+    ? rootPkg.workspaces
+    : rootPkg.workspaces?.packages ?? [];
+
+  for (const pattern of patterns) {
+    const dirs = globSync(pattern, {
+      cwd: projectRoot,
+      ignore: ["node_modules/**"],
+    });
+    for (const dir of dirs) {
+      const pkgPath = resolve(projectRoot, dir, "package.json");
+      if (!existsSync(pkgPath)) continue;
+      try {
+        const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+        if (pkg.name) names.add(pkg.name);
+      } catch {
+        // Skip malformed package.json
+      }
+    }
+  }
+
+  return names;
+}
+
+function pathExists(
+  value: string,
+  projectRoot: string,
+  scaffoldRoot: string,
+  workspaceNames: Set<string>
+): boolean {
   // Try project root first (e.g. src/index.ts)
   if (existsSync(resolve(projectRoot, value))) return true;
 
@@ -52,6 +113,25 @@ function pathExists(value: string, projectRoot: string, scaffoldRoot: string): b
   if (value.startsWith(".mex/")) {
     const withoutPrefix = value.slice(".mex/".length);
     if (existsSync(resolve(projectRoot, withoutPrefix))) return true;
+  }
+
+  // Resolve scoped package references (e.g. @acme/ui, @acme/shared/utils)
+  const scopedMatch = value.match(SCOPED_PACKAGE);
+  if (scopedMatch) {
+    const pkgName = `@${scopedMatch[1]}/${scopedMatch[2]}`;
+
+    // Try Node's module resolution first (works for installed npm packages)
+    try {
+      const req = createRequire(resolve(projectRoot, "package.json"));
+      req.resolve(`${pkgName}/package.json`);
+      return true;
+    } catch {
+      // Fall through to workspace check
+    }
+
+    // Check workspace names (handles package managers that don't symlink
+    // all workspaces into node_modules, e.g. bun)
+    if (workspaceNames.has(pkgName)) return true;
   }
 
   // Bare filenames: search recursively — the file may exist in a subdirectory

--- a/test/checkers.test.ts
+++ b/test/checkers.test.ts
@@ -125,6 +125,67 @@ describe("checkPaths", () => {
     expect(issues).toHaveLength(1);
     expect(issues[0].severity).toBe("error");
   });
+
+  it("skips URL values instead of reporting missing paths", () => {
+    const claims = [
+      claim({ kind: "path", value: "https://example.com/docs" }),
+      claim({ kind: "path", value: "http://localhost:3000/api" }),
+      claim({ kind: "path", value: "ftp://files.example.com/readme.txt" }),
+      claim({ kind: "path", value: "file:///etc/hosts" }),
+      claim({ kind: "path", value: "//cdn.example.com/assets/app.js" }),
+    ];
+    const issues = checkPaths(claims, tmpDir, tmpDir);
+    expect(issues).toHaveLength(0);
+  });
+
+  it("resolves workspace package aliases from package.json workspaces", () => {
+    mkdirSync(join(tmpDir, "packages/ui"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, "package.json"),
+      JSON.stringify({ workspaces: ["packages/*"] })
+    );
+    writeFileSync(
+      join(tmpDir, "packages/ui/package.json"),
+      JSON.stringify({ name: "@acme/ui" })
+    );
+    const claims = [
+      claim({ kind: "path", value: "@acme/ui/button" }),
+      claim({ kind: "path", value: "@acme/ui" }),
+    ];
+    const issues = checkPaths(claims, tmpDir, tmpDir);
+    expect(issues).toHaveLength(0);
+  });
+
+  it("resolves workspace package aliases from pnpm-workspace.yaml", () => {
+    mkdirSync(join(tmpDir, "packages/shared"), { recursive: true });
+    writeFileSync(join(tmpDir, "package.json"), JSON.stringify({ name: "root" }));
+    writeFileSync(
+      join(tmpDir, "pnpm-workspace.yaml"),
+      "packages:\n  - 'packages/*'\n"
+    );
+    writeFileSync(
+      join(tmpDir, "packages/shared/package.json"),
+      JSON.stringify({ name: "@acme/shared" })
+    );
+    const claims = [claim({ kind: "path", value: "@acme/shared/types" })];
+    const issues = checkPaths(claims, tmpDir, tmpDir);
+    expect(issues).toHaveLength(0);
+  });
+
+  it("resolves installed scoped packages via require.resolve", () => {
+    const pkgDir = join(tmpDir, "node_modules/@scope/pkg");
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(
+      join(pkgDir, "package.json"),
+      JSON.stringify({ name: "@scope/pkg", main: "index.js" })
+    );
+    writeFileSync(join(pkgDir, "index.js"), "module.exports = {};\n");
+    writeFileSync(join(tmpDir, "package.json"), JSON.stringify({ name: "test-root" }));
+
+    const claims = [claim({ kind: "path", value: "@scope/pkg/lib" })];
+    const issues = checkPaths(claims, tmpDir, tmpDir);
+    expect(issues).toHaveLength(0);
+  });
 });
 
 // ── Edges Checker ──


### PR DESCRIPTION
## Summary

Addresses all review feedback on #17. Same feature (workspace alias resolution + URL filtering) with the requested fixes applied.

Supersedes/updates #17 — review fixes are on this branch because the original author fork does not have push access from maintainers yet.

### Review feedback addressed

- **HIGH — pnpm workspace support:** `collectWorkspacePatterns()` falls back to `pnpm-workspace.yaml` when root `package.json` has no `workspaces` field.
- **MEDIUM — URL regex:** Broadened to `^(?:https?|ftp|file):\/\/|^\/\/` for `ftp://`, `file:///`, and protocol-relative URLs.
- **MEDIUM — createRequire anchor:** Uses `createRequire(resolve(projectRoot, "noop.js"))`.
- **LOW — Tests:** Four new path-checker tests (URL skip, package.json workspaces, pnpm-workspace.yaml, require.resolve).

## Test plan

- [x] All 87 tests pass
- [x] `tsc --noEmit` clean


Made with [Cursor](https://cursor.com)