### PR TITLE
fix(cli): use pathToFileURL for portable main-module guard

### DIFF
--- a/patterns/cli-option-parsing-tests.md
+++ b/patterns/cli-option-parsing-tests.md
@@ -15,7 +15,7 @@ last_updated: 2026-05-21
 # CLI Option Parsing Tests
 
 ## Context
-`src/cli.ts` calls `program.parse()` at import time. Do not import its `program` object in tests. If parser helpers must be imported from `src/cli.ts`, control `process.argv` during a dynamic import and suppress console output.
+`src/cli.ts` auto-parses only when invoked as the main script (`import.meta.url === pathToFileURL(process.argv[1]).href`). Do not import its `program` object in tests. If parser helpers must be imported from `src/cli.ts`, set `process.argv[1]` to a non-matching path during the dynamic import and suppress console output so the guard stays false.
 
 ## Steps
 1. Export narrow parser helpers from `src/cli.ts` when direct unit coverage is needed.

--- a/patterns/cli-option-parsing-tests.md
+++ b/patterns/cli-option-parsing-tests.md
@@ -15,7 +15,7 @@ last_updated: 2026-05-21
 # CLI Option Parsing Tests
 
 ## Context
-`src/cli.ts` auto-parses only when invoked as the main script (`import.meta.url === pathToFileURL(process.argv[1]).href`). Do not import its `program` object in tests. If parser helpers must be imported from `src/cli.ts`, set `process.argv[1]` to a non-matching path during the dynamic import and suppress console output so the guard stays false.
+`src/cli.ts` auto-parses only when invoked as the main script (`import.meta.url === pathToFileURL(realpathSync(process.argv[1])).href`). Do not import its `program` object in tests. If parser helpers must be imported from `src/cli.ts`, set `process.argv[1]` to a non-matching path during the dynamic import and suppress console output so the guard stays false.
 
 ## Steps
 1. Export narrow parser helpers from `src/cli.ts` when direct unit coverage is needed.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,6 @@
 import chalk from "chalk";
 import { Command, InvalidArgumentError } from "commander";
+import { realpathSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 import { findConfig } from "./config.js";
 import { reportConsole, reportQuiet, reportJSON, reportVerbose } from "./reporter.js";
@@ -303,8 +304,17 @@ program
 
 // Skip auto-parse when imported (e.g. by tests). The bin entry is built by
 // tsup as ./dist/cli.js with a shebang banner; only run program.parse() when
-// this module is the script being invoked.
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+// this module is the script being invoked. Resolve argv[1] so symlinked bins
+// (npm global, npx, node_modules/.bin) match import.meta.url.
+let isMainModule = false;
+if (process.argv[1]) {
+  try {
+    isMainModule = import.meta.url === pathToFileURL(realpathSync(process.argv[1])).href;
+  } catch {
+    // argv[1] is missing or not on disk (e.g. test fixtures) — not the main entry.
+  }
+}
+if (isMainModule) {
   program.parse();
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,6 @@
 import chalk from "chalk";
 import { Command, InvalidArgumentError } from "commander";
+import { pathToFileURL } from "node:url";
 import { findConfig } from "./config.js";
 import { reportConsole, reportQuiet, reportJSON, reportVerbose } from "./reporter.js";
 import { VERSION } from "./version.js";
@@ -300,7 +301,12 @@ program
     console.log();
   });
 
-program.parse();
+// Skip auto-parse when imported (e.g. by tests). The bin entry is built by
+// tsup as ./dist/cli.js with a shebang banner; only run program.parse() when
+// this module is the script being invoked.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  program.parse();
+}
 
 function buildCompletion(shell: string): string {
   const commands = [

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from "vitest";
 import { Command, InvalidArgumentError } from "commander";
-import { readFileSync } from "node:fs";
+import { execSync, spawnSync } from "node:child_process";
+import { readFileSync, symlinkSync, mkdtempSync, rmSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { runLog, runTimeline } from "../src/events.js";
 import type { MexConfig } from "../src/types.js";
@@ -205,6 +207,43 @@ describe("mex timeline parsing", () => {
       since: "30d",
       type: "risk",
     });
+  });
+});
+
+describe("built CLI main-module guard", () => {
+  const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+  const cliPath = join(repoRoot, "dist", "cli.js");
+  const pkg = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8")) as { version: string };
+
+  beforeAll(() => {
+    execSync("npm run build", { cwd: repoRoot, stdio: "pipe" });
+  });
+
+  it("parses argv when invoked through a symlinked bin (npm/npx layout)", () => {
+    const binDir = mkdtempSync(join(tmpdir(), "mex-bin-"));
+    const symlinkedCli = join(binDir, "mex");
+    try {
+      symlinkSync(cliPath, symlinkedCli);
+      const result = spawnSync(process.execPath, [symlinkedCli, "--version"], {
+        encoding: "utf8",
+        env: { ...process.env, NO_COLOR: "1" },
+      });
+      expect(result.status).toBe(0);
+      expect((result.stdout ?? "").trim()).toBe(pkg.version);
+    } finally {
+      rmSync(binDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not auto-parse when dist/cli.js is imported as a module", () => {
+    const result = spawnSync(
+      process.execPath,
+      ["-e", "import('./dist/cli.js').then(() => console.log('imported'))"],
+      { cwd: repoRoot, encoding: "utf8" },
+    );
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("imported");
+    expect(result.stdout).not.toContain(pkg.version);
   });
 });
 


### PR DESCRIPTION
Addresses the remaining review feedback on #46.

## Context

CLI-level test coverage for `mex log` / `mex timeline` option parsing already merged via #47. PR #46's review requested a portable main-module guard; this PR lands it with symlink-safe resolution for npm global / npx / `node_modules/.bin` layouts.

## Change

- Import `realpathSync` from `node:fs` and `pathToFileURL` from `node:url`
- Gate `program.parse()` on `import.meta.url === pathToFileURL(realpathSync(process.argv[1])).href` (try/catch when `argv[1]` is absent, e.g. test imports)
- Integration tests: built CLI via symlinked bin (`--version`) and import-without-auto-parse
- Updated `patterns/cli-option-parsing-tests.md` to document the guard

## Verification

- `npx vitest run test/cli.test.ts` — 13/13 passing
- `npm test` — 181/181 passing
- `npm run typecheck` — passing
- Rebased on latest `main` (includes #68)

Closes the actionable items from @theDakshJaitly's review on #46. Supersedes accidentally closed #67 after a bad force-push orphaned the PR head.