### PR TITLE
feat: anonymous opt-out telemetry (PostHog)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- **Anonymous telemetry** — opt-out usage counting via PostHog. Each command sends one event with only `machine_id`, `scaffold_id`, `command` name, `mex_version`, `os`, and `node_version` — no args, paths, file contents, repo names, IP, or location. Opt out with `DO_NOT_TRACK=1`, `MEX_TELEMETRY=0`, or `mex config set telemetry off`. Audit the exact payload with `mex telemetry inspect`; check state with `mex telemetry status`. Telemetry is disabled automatically when running from a clone of the mex repo. See [TELEMETRY.md](TELEMETRY.md).
 - **Scaffold identity** — `.mex/config.json` now carries a stable `scaffold_id` (UUID v4), `scaffold_name`, and nullable `origin`/`upstream`. Generated at `mex setup` and silently backfilled for existing scaffolds on the next CLI invocation. New `getScaffoldIdentity()` export on the public API.
 - **broken-link drift checker** — flags Markdown links in scaffold files whose local target file does not exist.
 

--- a/README.md
+++ b/README.md
@@ -262,6 +262,10 @@ Optional settings live in `.mex/config.json`. Missing values fall back to defaul
 }
 ```
 
+## Telemetry
+
+mex collects anonymous, opt-out usage data (command name, version, OS — never paths, args, file contents, IP, or personal data) to understand how the tool is used. Audit the exact payload with `mex telemetry inspect`, and opt out any time with `DO_NOT_TRACK=1`, `MEX_TELEMETRY=0`, or `mex config set telemetry off`. Full details: [TELEMETRY.md](TELEMETRY.md).
+
 ## Ecosystem
 
 mex is provider-neutral. Integration guides, sponsored examples, and community recipes should be useful on their own, clearly labeled, and live in docs rather than silently changing the default experience.

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,0 +1,95 @@
+# Telemetry
+
+mex collects **anonymous, opt-out** usage data so the maintainer can see how the
+tool is actually used — which commands matter, roughly how many people use it,
+and whether a project is used by a team. That's the entire purpose. There is no
+advertising, no profiling, and no way to tie any data back to a person.
+
+If you'd rather send nothing, see [How to opt out](#how-to-opt-out) — it's one
+command or one environment variable.
+
+## What is collected
+
+Every time you run a `mex` command, **one** event is sent containing **exactly**
+these fields and nothing else:
+
+| Field | Example | What it is |
+|-------|---------|------------|
+| `machine_id` | `3f2a…` (random UUID) | A random ID generated once per machine. Not your username, hostname, or anything derived from you. |
+| `scaffold_id` | `9b1c…` (random UUID) | A random ID for the mex scaffold (project). Only present when you run inside a scaffold. Lets us tell "one team on one project" apart from "one person on many machines." |
+| `command` | `check` | The command **name only** — e.g. `check`, `sync`, `log`. |
+| `mex_version` | `0.5.1` | The installed mex version. |
+| `os` | `darwin` | The platform string (`darwin` / `linux` / `win32`). |
+| `node_version` | `v22.17.1` | The Node.js version. |
+
+You can see the literal payload that would be sent, at any time, without sending
+anything:
+
+```bash
+mex telemetry inspect
+```
+
+## What is NEVER collected
+
+- **No personal data** — no name, email, username, hostname, or git identity.
+- **No IP address or location** — geolocation is explicitly disabled.
+- **No command arguments, flags, or paths.**
+- **No file names or file contents.**
+- **No repository name or git remote URL.**
+
+`machine_id` and `scaffold_id` are random UUIDs. They are **not** derived from
+your path, repo, email, or anything identifying — they are just random numbers
+that let counts be de-duplicated.
+
+## Where the data goes
+
+[PostHog](https://posthog.com) Cloud, **US region** (`https://us.i.posthog.com`).
+The ingestion key embedded in mex is write-only — it can send events but cannot
+read any data back.
+
+## When telemetry does NOT run
+
+Telemetry is automatically disabled — no event sent, no ID file created — when:
+
+- any opt-out below is active, **or**
+- mex is run from a clone of the mex repository itself (so the maintainer's own
+  development never pollutes the data), **or**
+- the command is run in a non-interactive context where it would be noise.
+
+A telemetry failure (offline, firewall, ad-blocker) never blocks, slows, or
+changes the exit code of any command. It is fire-and-forget and fully ignored on
+error.
+
+## How to opt out
+
+Any **one** of these turns telemetry off completely. When off, no event is ever
+sent and the machine-id file is never created.
+
+| Method | Scope |
+|--------|-------|
+| `DO_NOT_TRACK=1` | The industry-standard env var. Honored everywhere. |
+| `MEX_TELEMETRY=0` | mex-specific env var. |
+| `mex config set telemetry off` | Persisted in `~/.mex/config.json` (per-machine). Re-enable with `mex config set telemetry on`. |
+
+Check the current state and the active opt-out reason any time:
+
+```bash
+mex telemetry status
+```
+
+## Files mex writes for telemetry
+
+- `~/.mex/telemetry-id` — your random `machine_id` (mode `0600`). Created only
+  when telemetry is enabled. Delete it any time; a new one is generated on the
+  next enabled run.
+- `~/.mex/config.json` — your global preferences, including the telemetry
+  opt-out flag.
+
+These are separate from a project's `.mex/config.json`, which holds the
+project's `scaffold_id`.
+
+## A note on PostHog metadata
+
+The PostHog client library attaches two of its own fields to each event —
+`$lib` (`posthog-node`) and `$lib_version`. These describe the sending library,
+not you, and contain no personal or usage data.

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -53,8 +53,7 @@ Telemetry is automatically disabled — no event sent, no ID file created — wh
 
 - any opt-out below is active, **or**
 - mex is run from a clone of the mex repository itself (so the maintainer's own
-  development never pollutes the data), **or**
-- the command is run in a non-interactive context where it would be noise.
+  development never pollutes the data).
 
 A telemetry failure (offline, firewall, ad-blocker) never blocks, slows, or
 changes the exit code of any command. It is fire-and-forget and fully ignored on

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "commander": "^13.1.0",
         "glob": "^11.0.1",
         "ink": "^7.0.3",
+        "posthog-node": "^5.21.2",
         "react": "^19.2.6",
         "remark-frontmatter": "^5.0.0",
         "remark-parse": "^11.0.0",
@@ -553,6 +554,15 @@
       "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
       "license": "MIT"
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-Xk3JQ+cdychsvftrV3G9ZrN9W329lbyFW0pGJXFGKFQf8qr4upw2SgNg9BVorjSrfhoXZRnJGt/uNF4nGFBL5A==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.6"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.59.1",
@@ -2753,6 +2763,18 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/posthog-node": {
+      "version": "5.21.2",
+      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.21.2.tgz",
+      "integrity": "sha512-Jehlu0KguL1LLyUczCt86OtA5INmeStK3zcgbv1BSyMcNxs0HP3GQogBrYhwhqHsk6JopiFFVpJyZEoXOUMhGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/core": "1.10.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/react": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "commander": "^13.1.0",
     "glob": "^11.0.1",
     "ink": "^7.0.3",
+    "posthog-node": "^5.21.2",
     "react": "^19.2.6",
     "remark-frontmatter": "^5.0.0",
     "remark-parse": "^11.0.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -53,6 +53,12 @@ async function runTuiCommand(): Promise<void> {
 // scaffold_id is resolved read-only (never mints). Telemetry never throws here.
 program.hook("preAction", (_thisCommand, actionCommand) => {
   try {
+    // Never count the telemetry/config meta-commands. In particular,
+    // `telemetry inspect` must have zero side effects — no event sent, no
+    // machine-id file created — so it stays a pure audit surface.
+    const parentName = actionCommand.parent?.name();
+    if (parentName === "telemetry" || parentName === "config") return;
+
     let scaffoldId: string | undefined;
     try {
       scaffoldId = readScaffoldId(findConfig().scaffoldRoot);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,9 +2,11 @@ import chalk from "chalk";
 import { Command, InvalidArgumentError } from "commander";
 import { realpathSync } from "node:fs";
 import { pathToFileURL } from "node:url";
-import { findConfig, getScaffoldIdentity } from "./config.js";
+import { findConfig, getScaffoldIdentity, readScaffoldId } from "./config.js";
 import { reportConsole, reportQuiet, reportJSON, reportVerbose } from "./reporter.js";
 import { VERSION } from "./version.js";
+import { captureCommand, flush, isEnabled, getPayloadPreview, showFirstRunNotice } from "./telemetry/index.js";
+import { readMachineId, setGlobalConfigKey } from "./global-config.js";
 
 /**
  * Load config for a CLI command and backfill scaffold identity on the way.
@@ -40,6 +42,39 @@ async function runTuiCommand(): Promise<void> {
   const { launchTui } = await import("./tui.js");
   launchTui();
 }
+
+// ── Telemetry hooks ──
+
+// preAction: fire the event at the START of the command. Two reasons:
+//  - the async request gets the whole command runtime to land in the background
+//  - commands that call process.exit() (e.g. `check` on drift) are still
+//    counted; a postAction hook would never run after process.exit and would
+//    systematically miss every error/drift outcome.
+// scaffold_id is resolved read-only (never mints). Telemetry never throws here.
+program.hook("preAction", (_thisCommand, actionCommand) => {
+  try {
+    let scaffoldId: string | undefined;
+    try {
+      scaffoldId = readScaffoldId(findConfig().scaffoldRoot);
+    } catch {
+      // No scaffold (or not in one) — omit scaffold_id.
+    }
+    captureCommand(actionCommand.name(), scaffoldId);
+  } catch {
+    // Telemetry must never affect command behaviour.
+  }
+});
+
+// postAction: best-effort bounded flush for commands that exit naturally.
+// Commands that process.exit() skip this, but their event was already sent
+// from preAction (flushAt:1 fires the request immediately).
+program.hook("postAction", async () => {
+  try {
+    await flush();
+  } catch {
+    // Telemetry must never affect command behaviour.
+  }
+});
 
 program
   .name("mex")
@@ -283,6 +318,74 @@ program
     }
   });
 
+// ── Telemetry ──
+const telemetryCmd = program
+  .command("telemetry")
+  .description("Telemetry transparency commands");
+
+telemetryCmd
+  .command("inspect")
+  .description("Print the exact JSON payload that would be sent (without sending it)")
+  .action(() => {
+    try {
+      // Read-only: use readScaffoldId (never mints), not getScaffoldIdentity
+      let scaffoldId: string | undefined;
+      try {
+        const config = findConfig();
+        scaffoldId = readScaffoldId(config.scaffoldRoot);
+      } catch { /* no scaffold — omit scaffold_id */ }
+
+      // Read-only: show the machine_id only if it already exists. Auditing the
+      // payload must never plant the tracking file on disk.
+      const machineId = readMachineId();
+
+      const payload = getPayloadPreview("inspect", scaffoldId, machineId);
+      console.log(JSON.stringify(payload, null, 2));
+    } catch (err) {
+      console.error((err as Error).message);
+      process.exit(1);
+    }
+  });
+
+telemetryCmd
+  .command("status")
+  .description("Show whether telemetry is enabled and the active opt-out reason")
+  .action(() => {
+    const result = isEnabled();
+    if (result.enabled) {
+      console.log("Telemetry: enabled");
+    } else {
+      console.log(`Telemetry: disabled (reason: ${result.reason})`);
+    }
+  });
+
+// ── Config ──
+const configCmd = program
+  .command("config")
+  .description("Manage global mex configuration");
+
+configCmd
+  .command("set <key> <value>")
+  .description("Set a global config value (e.g. telemetry on|off)")
+  .action((key: string, value: string) => {
+    try {
+      if (key === "telemetry") {
+        if (value !== "on" && value !== "off") {
+          console.error(`Invalid value "${value}" for telemetry. Use "on" or "off".`);
+          process.exit(1);
+        }
+        setGlobalConfigKey("telemetry", value);
+        console.log(`Telemetry set to "${value}" in ~/.mex/config.json`);
+      } else {
+        console.error(`Unknown config key "${key}". Supported keys: telemetry`);
+        process.exit(1);
+      }
+    } catch (err) {
+      console.error((err as Error).message);
+      process.exit(1);
+    }
+  });
+
 // ── Quick Reference ──
 program
   .command("commands")
@@ -309,15 +412,23 @@ program
     console.log("  mex watch              Install post-commit hook for auto drift score");
     console.log("  mex watch --interval   Run heartbeat every 30 minutes (or config value)");
     console.log("  mex watch --uninstall  Remove the post-commit hook");
+    console.log("  mex telemetry inspect  Show the exact telemetry payload (without sending)");
+    console.log("  mex telemetry status   Show telemetry enabled/disabled and reason");
+    console.log("  mex config set <k> <v> Set a global config value (e.g. telemetry off)");
     console.log();
     console.log(chalk.dim("Not installed globally? Replace 'mex' with 'npx mex-agent'."));
     console.log();
   });
 
 // Skip auto-parse when imported (e.g. by tests). The bin entry is built by
-// tsup as ./dist/cli.js with a shebang banner; only run program.parse() when
-// this module is the script being invoked. Resolve argv[1] so symlinked bins
-// (npm global, npx, node_modules/.bin) match import.meta.url.
+// tsup as ./dist/cli.js with a shebang banner; only run program.parseAsync()
+// when this module is the script being invoked. Resolve argv[1] so symlinked
+// bins (npm global, npx, node_modules/.bin) match import.meta.url.
+//
+// Critical: use parseAsync(), not parse(). Commander's sync parse() does not
+// await the promise chain built by hooks and async actions — preAction/
+// postAction hooks would silently never execute and telemetry events would
+// never flush.
 let isMainModule = false;
 if (process.argv[1]) {
   try {
@@ -327,13 +438,18 @@ if (process.argv[1]) {
   }
 }
 if (isMainModule) {
-  program.parse();
+  showFirstRunNotice();
+  program.parseAsync().catch((err: Error) => {
+    console.error(err.message);
+    process.exit(1);
+  });
 }
 
 function buildCompletion(shell: string): string {
   const commands = [
     "setup", "check", "init", "sync", "pattern", "log", "timeline",
     "heartbeat", "doctor", "watch", "tui", "commands", "completion",
+    "telemetry", "config",
   ];
   if (shell === "bash") {
     return `_mex_completion() {

--- a/src/config.ts
+++ b/src/config.ts
@@ -314,3 +314,15 @@ function findScaffoldRoot(projectRoot: string): string | null {
 
   return null;
 }
+
+/**
+ * Read-only scaffold_id lookup. Returns the scaffold_id string if it exists
+ * in config.json, or `undefined` if not. **Never mints or writes anything.**
+ *
+ * Used by telemetry inspect to show the payload without side-effects.
+ */
+export function readScaffoldId(scaffoldRoot: string): string | undefined {
+  const raw = loadPersistedConfig(scaffoldRoot);
+  const identity = loadScaffoldIdentity(raw);
+  return identity?.scaffold_id;
+}

--- a/src/global-config.ts
+++ b/src/global-config.ts
@@ -7,7 +7,7 @@
  * Completely separate from the per-scaffold config in `src/config.ts`.
  */
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync, constants } from "node:fs";
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { randomUUID } from "node:crypto";
 import { homedir } from "node:os";
@@ -107,7 +107,8 @@ export function setGlobalConfigKey(key: string, value: unknown): void {
  * Checks: `MEX_DEV` env var, or `package.json` name matches the mex package.
  *
  * Generalized from `setup/index.ts:127-138` — checks the real package name
- * `mex-agent` plus legacy names `promexeus` and `mex` for safety.
+ * `mex-agent` plus the legacy name `promexeus`. The bare `mex` name is
+ * intentionally excluded (too generic — see the inline note below).
  */
 export function isDevRepo(): boolean {
   if (process.env.MEX_DEV) return true;

--- a/src/global-config.ts
+++ b/src/global-config.ts
@@ -1,0 +1,146 @@
+/**
+ * Global (per-machine) config under `~/.mex/`.
+ *
+ * Owns: `~/.mex/telemetry-id` (machine UUID) and `~/.mex/config.json`
+ * (global preferences like telemetry opt-out).
+ *
+ * Completely separate from the per-scaffold config in `src/config.ts`.
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync, constants } from "node:fs";
+import { join, resolve } from "node:path";
+import { randomUUID } from "node:crypto";
+import { homedir } from "node:os";
+
+// ── Paths ──
+
+const MEX_HOME_DIR_NAME = ".mex";
+const TELEMETRY_ID_FILE = "telemetry-id";
+const GLOBAL_CONFIG_FILE = "config.json";
+
+/** Absolute path to `~/.mex`. Respects `$HOME`. */
+export function mexHomeDir(): string {
+  return join(homedir(), MEX_HOME_DIR_NAME);
+}
+
+/** Create `~/.mex/` if it doesn't exist. */
+export function ensureMexHomeDir(): void {
+  const dir = mexHomeDir();
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+}
+
+// ── Machine ID ──
+
+/**
+ * Read `~/.mex/telemetry-id` if it already exists, without creating it.
+ * Returns `undefined` when the file is absent or empty. Use this for read-only
+ * paths (e.g. `telemetry inspect`) that must not plant a tracking id on disk.
+ */
+export function readMachineId(): string | undefined {
+  const filePath = join(mexHomeDir(), TELEMETRY_ID_FILE);
+  if (!existsSync(filePath)) return undefined;
+  try {
+    const existing = readFileSync(filePath, "utf-8").trim();
+    return existing.length > 0 ? existing : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Read or create `~/.mex/telemetry-id`. Mode `0600` so only the owner can read.
+ *
+ * **Caller must guarantee telemetry is enabled before calling.** When disabled,
+ * this file must not exist.
+ */
+export function getMachineId(): string {
+  const existing = readMachineId();
+  if (existing) return existing;
+
+  ensureMexHomeDir();
+  const id = randomUUID();
+  writeFileSync(join(mexHomeDir(), TELEMETRY_ID_FILE), id + "\n", { mode: 0o600 });
+  return id;
+}
+
+// ── Global config ──
+
+interface GlobalConfig {
+  telemetry?: "on" | "off";
+  firstRunNoticeShown?: boolean;
+  [key: string]: unknown;
+}
+
+/**
+ * Read `~/.mex/config.json`. Returns `{}` if missing or malformed — tolerant
+ * parse matching the style of `loadPersistedConfig` in `src/config.ts`.
+ */
+export function readGlobalConfig(): GlobalConfig {
+  const filePath = join(mexHomeDir(), GLOBAL_CONFIG_FILE);
+  if (!existsSync(filePath)) return {};
+  try {
+    const raw = JSON.parse(readFileSync(filePath, "utf-8"));
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return {};
+    return raw as GlobalConfig;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Set a single key in `~/.mex/config.json`, preserving all other keys.
+ */
+export function setGlobalConfigKey(key: string, value: unknown): void {
+  ensureMexHomeDir();
+  const filePath = join(mexHomeDir(), GLOBAL_CONFIG_FILE);
+  const existing = readGlobalConfig();
+  existing[key] = value;
+  writeFileSync(filePath, JSON.stringify(existing, null, 2) + "\n");
+}
+
+// ── Dev-repo guard ──
+
+/**
+ * Detect whether we're running from a clone of the mex repo itself.
+ * Checks: `MEX_DEV` env var, or `package.json` name matches the mex package.
+ *
+ * Generalized from `setup/index.ts:127-138` — checks the real package name
+ * `mex-agent` plus legacy names `promexeus` and `mex` for safety.
+ */
+export function isDevRepo(): boolean {
+  if (process.env.MEX_DEV) return true;
+
+  try {
+    // Walk up from cwd to find the nearest package.json
+    let dir = process.cwd();
+    while (true) {
+      const pkgPath = join(dir, "package.json");
+      if (existsSync(pkgPath)) {
+        const content = readFileSync(pkgPath, "utf-8");
+        try {
+          const pkg = JSON.parse(content) as { name?: string };
+          const name = pkg.name;
+          // Match the real package name and the legacy "promexeus". The bare
+          // "mex" name is intentionally excluded — too generic, and combined
+          // with a src/cli.ts it could disable telemetry in a user's project.
+          if (name === "mex-agent" || name === "promexeus") {
+            // Double-check: must also have src/telemetry or src/cli.ts to be
+            // the actual dev repo, not a random package that happens to share
+            // a name.
+            if (existsSync(join(dir, "src", "cli.ts"))) {
+              return true;
+            }
+          }
+        } catch { /* malformed JSON — not a dev repo */ }
+        break; // found a package.json, stop walking
+      }
+      const parent = resolve(dir, "..");
+      if (parent === dir) break;
+      dir = parent;
+    }
+  } catch { /* best-effort */ }
+
+  return false;
+}

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -196,19 +196,23 @@ export function captureCommand(command: string, scaffoldId?: string): void {
  * interval timer so the Node.js process can exit promptly.
  */
 export async function flush(): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
   try {
     if (customTransport || !client) {
       // No real client to flush — nothing to do.
       return;
     }
 
-    const timeoutPromise = new Promise<void>((resolve) =>
-      setTimeout(resolve, FLUSH_TIMEOUT_MS),
-    );
+    const timeoutPromise = new Promise<void>((resolve) => {
+      timer = setTimeout(resolve, FLUSH_TIMEOUT_MS);
+    });
     await Promise.race([client.flush(), timeoutPromise]);
   } catch {
     // Swallow — delivery is best-effort.
   } finally {
+    // Clear the race timer so a fast flush doesn't leave it pending and delay
+    // process exit.
+    if (timer) clearTimeout(timer);
     try {
       if (client) {
         await client.shutdown();

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -1,0 +1,258 @@
+/**
+ * Anonymous, opt-out telemetry — PostHog counting layer.
+ *
+ * Trust constraint: a developer who reads this file must trust it.
+ * - Only 6 whitelisted fields are ever sent (see `buildPayload`).
+ * - No PII, no args, no paths, no file contents, no repo names.
+ * - Failures are swallowed — telemetry never affects command behaviour.
+ * - The PostHog client is the only network-touching code in this module.
+ *
+ * All PostHog-specific code lives behind this interface so the backend can
+ * be swapped to a self-hosted endpoint in one file.
+ */
+
+import { PostHog } from "posthog-node";
+import { getMachineId, readGlobalConfig, setGlobalConfigKey, isDevRepo } from "../global-config.js";
+import { VERSION } from "../version.js";
+import { platform } from "node:os";
+
+// ── Constants ──
+
+const TELEMETRY_KEY = "phc_wdwbBPQMrM6vKWMzz5yqWT357i2hSjMhnAvCuofJdMpg";
+const HOST = "https://us.i.posthog.com";
+const EVENT = "command_run";
+const FLUSH_TIMEOUT_MS = 800;
+
+// ── Opt-out check ──
+
+export interface EnabledResult {
+  enabled: boolean;
+  reason?: string;
+}
+
+/**
+ * Determine whether telemetry is enabled.
+ *
+ * Precedence (first match wins):
+ * 1. `DO_NOT_TRACK=1` → off
+ * 2. `MEX_TELEMETRY=0` → off
+ * 3. Dev repo / `MEX_DEV` → off
+ * 4. `~/.mex/config.json` `telemetry === "off"` → off
+ * 5. else → on
+ *
+ * Env + dev checks run before any disk read.
+ */
+export function isEnabled(): EnabledResult {
+  // 1. Industry-standard opt-out
+  if (process.env.DO_NOT_TRACK === "1") {
+    return { enabled: false, reason: "DO_NOT_TRACK" };
+  }
+
+  // 2. mex-specific env opt-out
+  if (process.env.MEX_TELEMETRY === "0") {
+    return { enabled: false, reason: "MEX_TELEMETRY" };
+  }
+
+  // 3. Dev-repo guard (no disk read for global config yet)
+  if (isDevRepo()) {
+    return { enabled: false, reason: "dev" };
+  }
+
+  // 4. Global config opt-out
+  try {
+    const globalConfig = readGlobalConfig();
+    if (globalConfig.telemetry === "off") {
+      return { enabled: false, reason: "config" };
+    }
+  } catch { /* tolerate read failure — default to enabled */ }
+
+  // 5. Default: enabled
+  return { enabled: true };
+}
+
+// ── Payload construction ──
+
+/**
+ * The single place the payload shape is defined. Exactly 6 keys — nothing else.
+ *
+ * PII firewall: `scaffold_id` is a **string** (random UUID). Never pass the
+ * full `ScaffoldIdentity` object — it contains `scaffold_name` (directory
+ * basename), `origin`, and `upstream` which must never reach PostHog.
+ */
+export function buildPayload(
+  command: string,
+  scaffold_id?: string,
+): Record<string, string> {
+  const payload: Record<string, string> = {
+    machine_id: "", // placeholder — filled by capture() when actually sending
+    command,
+    mex_version: VERSION,
+    os: platform(),
+    node_version: process.version,
+  };
+  if (scaffold_id) {
+    payload.scaffold_id = scaffold_id;
+  }
+  return payload;
+}
+
+/**
+ * Build the payload that *would* be sent, for `mex telemetry inspect`.
+ *
+ * Uses a read-only identity lookup — never mints a scaffold_id on disk.
+ * Does NOT send anything or touch the network.
+ *
+ * `scaffoldId` is passed in by the CLI after a read-only config lookup.
+ */
+export function getPayloadPreview(
+  command: string,
+  scaffoldId?: string,
+  machineId?: string,
+): Record<string, string> {
+  const payload = buildPayload(command, scaffoldId);
+  payload.machine_id = machineId ?? "(not generated — telemetry disabled or inspect-only)";
+  return payload;
+}
+
+// ── PostHog client (lazy, with test seam) ──
+
+type TransportFn = (event: string, properties: Record<string, unknown>) => void;
+
+let client: PostHog | null = null;
+let customTransport: TransportFn | null = null;
+
+function getClient(): PostHog {
+  if (!client) {
+    client = new PostHog(TELEMETRY_KEY, {
+      host: HOST,
+      flushAt: 1,       // flush after every event (short-lived CLI)
+      flushInterval: 0, // don't auto-flush on interval — we call flush() explicitly
+    });
+  }
+  return client;
+}
+
+/**
+ * Test seam: inject a fake transport so tests never hit the network.
+ * Pass `null` to restore the real PostHog client.
+ */
+export function __setTransport(fn: TransportFn | null): void {
+  customTransport = fn;
+}
+
+// ── Capture + flush ──
+
+/**
+ * Capture a telemetry event. Enqueues synchronously — no await needed.
+ *
+ * If telemetry is disabled, returns immediately.
+ * All errors are swallowed — telemetry must never affect command behaviour.
+ */
+export function capture(event: string, command: string, scaffoldId?: string): void {
+  try {
+    const { enabled } = isEnabled();
+    if (!enabled) return;
+
+    const machineId = getMachineId();
+    const payload = buildPayload(command, scaffoldId);
+    payload.machine_id = machineId;
+
+    if (customTransport) {
+      customTransport(event, payload);
+      return;
+    }
+
+    const ph = getClient();
+    ph.capture({
+      distinctId: machineId,
+      event,
+      properties: payload,
+      // Anonymous: tell PostHog not to derive geolocation from the request IP.
+      // Without this, the server attaches IP-based geo — PII that would NOT
+      // show up in `mex telemetry inspect`, breaking the whitelist promise.
+      // (posthog-node still adds $lib / $lib_version library metadata — not
+      // user data; disclosed in TELEMETRY.md.)
+      disableGeoip: true,
+    });
+  } catch {
+    // Swallow everything — telemetry must never throw.
+  }
+}
+
+/**
+ * Capture a `command_run` event. This is the main entry point from CLI hooks.
+ *
+ * `scaffoldId` is the **string** scaffold_id only — never the full
+ * ScaffoldIdentity object. This is the PII firewall.
+ */
+export function captureCommand(command: string, scaffoldId?: string): void {
+  capture(EVENT, command, scaffoldId);
+}
+
+/**
+ * Best-effort, time-bounded flush + unconditional shutdown.
+ *
+ * After the flush (or timeout), `posthog.shutdown()` clears the internal
+ * interval timer so the Node.js process can exit promptly.
+ */
+export async function flush(): Promise<void> {
+  try {
+    if (customTransport || !client) {
+      // No real client to flush — nothing to do.
+      return;
+    }
+
+    const timeoutPromise = new Promise<void>((resolve) =>
+      setTimeout(resolve, FLUSH_TIMEOUT_MS),
+    );
+    await Promise.race([client.flush(), timeoutPromise]);
+  } catch {
+    // Swallow — delivery is best-effort.
+  } finally {
+    try {
+      if (client) {
+        await client.shutdown();
+        client = null;
+      }
+    } catch {
+      // Swallow shutdown errors too.
+    }
+  }
+}
+
+// ── First-run notice ──
+
+/**
+ * Show a one-time first-run notice to stderr if telemetry is enabled.
+ * Returns true if the notice was shown.
+ */
+export function showFirstRunNotice(): boolean {
+  try {
+    const { enabled } = isEnabled();
+    if (!enabled) return false;
+
+    const config = readGlobalConfig();
+    if (config.firstRunNoticeShown) return false;
+
+    // Skip in non-TTY to avoid noise in pipes
+    if (!process.stderr.isTTY) return false;
+
+    process.stderr.write(
+      "\n" +
+      "  mex collects anonymous usage data (command name, version, OS) to\n" +
+      "  understand how the tool is used. No file contents, paths, or personal\n" +
+      "  data are ever collected. Run `mex telemetry inspect` to see the exact\n" +
+      "  payload sent.\n" +
+      "\n" +
+      "  To opt out: mex config set telemetry off\n" +
+      "  Or set DO_NOT_TRACK=1 or MEX_TELEMETRY=0\n" +
+      "\n",
+    );
+
+    setGlobalConfigKey("firstRunNoticeShown", true);
+    return true;
+  } catch {
+    // Never let the notice break a command.
+    return false;
+  }
+}

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -1,0 +1,457 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// We test via the module's public exports. Each test gets a fresh $HOME
+// so the global config / telemetry-id files are isolated.
+//
+// Important: tests run from the mex repo, so isDevRepo() returns true by
+// default. Tests that need telemetry ENABLED must chdir to a temp dir that
+// has no mex-agent package.json.
+
+let originalHome: string | undefined;
+let originalDoNotTrack: string | undefined;
+let originalMexTelemetry: string | undefined;
+let originalMexDev: string | undefined;
+let originalCwd: string;
+let tempHome: string;
+
+function setTempHome(): string {
+  tempHome = mkdtempSync(join(tmpdir(), "mex-tel-"));
+  process.env.HOME = tempHome;
+  return tempHome;
+}
+
+/** chdir to temp home so isDevRepo() returns false. */
+function exitDevRepo(): void {
+  process.chdir(tempHome);
+}
+
+/** Restore cwd to original. */
+function restoreCwd(): void {
+  process.chdir(originalCwd);
+}
+
+beforeEach(() => {
+  originalHome = process.env.HOME;
+  originalDoNotTrack = process.env.DO_NOT_TRACK;
+  originalMexTelemetry = process.env.MEX_TELEMETRY;
+  originalMexDev = process.env.MEX_DEV;
+  originalCwd = process.cwd();
+  delete process.env.DO_NOT_TRACK;
+  delete process.env.MEX_TELEMETRY;
+  delete process.env.MEX_DEV;
+  setTempHome();
+});
+
+afterEach(async () => {
+  restoreCwd();
+  process.env.HOME = originalHome;
+  if (originalDoNotTrack !== undefined) process.env.DO_NOT_TRACK = originalDoNotTrack;
+  else delete process.env.DO_NOT_TRACK;
+  if (originalMexTelemetry !== undefined) process.env.MEX_TELEMETRY = originalMexTelemetry;
+  else delete process.env.MEX_TELEMETRY;
+  if (originalMexDev !== undefined) process.env.MEX_DEV = originalMexDev;
+  else delete process.env.MEX_DEV;
+
+  // Reset module state between tests
+  const tel = await import("../src/telemetry/index.js");
+  tel.__setTransport(null);
+
+  rmSync(tempHome, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+// ── AC1: opt-out paths disable telemetry and prevent file creation ──
+
+describe("opt-out precedence (AC1)", () => {
+  it("DO_NOT_TRACK=1 disables telemetry", async () => {
+    process.env.DO_NOT_TRACK = "1";
+    const { isEnabled } = await import("../src/telemetry/index.js");
+    const result = isEnabled();
+    expect(result.enabled).toBe(false);
+    expect(result.reason).toBe("DO_NOT_TRACK");
+  });
+
+  it("MEX_TELEMETRY=0 disables telemetry", async () => {
+    process.env.MEX_TELEMETRY = "0";
+    const { isEnabled } = await import("../src/telemetry/index.js");
+    const result = isEnabled();
+    expect(result.enabled).toBe(false);
+    expect(result.reason).toBe("MEX_TELEMETRY");
+  });
+
+  it("global config telemetry=off disables telemetry", async () => {
+    exitDevRepo(); // leave the mex repo so dev guard doesn't fire first
+    const { isEnabled } = await import("../src/telemetry/index.js");
+    const { setGlobalConfigKey } = await import("../src/global-config.js");
+    setGlobalConfigKey("telemetry", "off");
+    const result = isEnabled();
+    expect(result.enabled).toBe(false);
+    expect(result.reason).toBe("config");
+  });
+
+  it("MEX_DEV disables telemetry", async () => {
+    process.env.MEX_DEV = "1";
+    const { isEnabled } = await import("../src/telemetry/index.js");
+    const result = isEnabled();
+    expect(result.enabled).toBe(false);
+    expect(result.reason).toBe("dev");
+  });
+
+  it("dev-repo guard fires (running from mex repo cwd)", async () => {
+    // We're in the mex repo by default — isDevRepo should detect it
+    const { isEnabled } = await import("../src/telemetry/index.js");
+    const result = isEnabled();
+    expect(result.enabled).toBe(false);
+    expect(result.reason).toBe("dev");
+  });
+
+  it("when disabled, capture sends nothing and no telemetry-id file is created", async () => {
+    process.env.DO_NOT_TRACK = "1";
+    const { capture, __setTransport } = await import("../src/telemetry/index.js");
+    const events: Array<{ event: string; properties: Record<string, unknown> }> = [];
+    __setTransport((event, properties) => events.push({ event, properties }));
+
+    capture("command_run", "check");
+
+    expect(events).toHaveLength(0);
+    expect(existsSync(join(tempHome, ".mex", "telemetry-id"))).toBe(false);
+  });
+});
+
+// ── AC2: payload whitelist — exactly 6 keys, PII fields absent ──
+
+describe("payload whitelist (AC2)", () => {
+  it("buildPayload returns exactly the 6 whitelisted keys", async () => {
+    const { buildPayload } = await import("../src/telemetry/index.js");
+    const payload = buildPayload("check", "test-scaffold-id");
+
+    const keys = Object.keys(payload).sort();
+    expect(keys).toEqual([
+      "command",
+      "machine_id",
+      "mex_version",
+      "node_version",
+      "os",
+      "scaffold_id",
+    ]);
+    expect(payload.command).toBe("check");
+    expect(payload.scaffold_id).toBe("test-scaffold-id");
+  });
+
+  it("omits scaffold_id when not provided", async () => {
+    const { buildPayload } = await import("../src/telemetry/index.js");
+    const payload = buildPayload("setup");
+
+    const keys = Object.keys(payload).sort();
+    expect(keys).toEqual([
+      "command",
+      "machine_id",
+      "mex_version",
+      "node_version",
+      "os",
+    ]);
+  });
+
+  it("scaffold_name, origin, and upstream NEVER appear in the payload", async () => {
+    const { buildPayload } = await import("../src/telemetry/index.js");
+    const payload = buildPayload("check", "some-id");
+
+    expect(payload).not.toHaveProperty("scaffold_name");
+    expect(payload).not.toHaveProperty("origin");
+    expect(payload).not.toHaveProperty("upstream");
+  });
+});
+
+// ── AC3: telemetry inspect — no send, read-only ──
+
+describe("getPayloadPreview (AC3)", () => {
+  it("returns whitelist-only JSON without sending", async () => {
+    const { getPayloadPreview, __setTransport } = await import("../src/telemetry/index.js");
+    const events: unknown[] = [];
+    __setTransport((event, props) => events.push({ event, props }));
+
+    const payload = getPayloadPreview("inspect", "scaffold-123", "machine-456");
+
+    expect(payload.command).toBe("inspect");
+    expect(payload.scaffold_id).toBe("scaffold-123");
+    expect(payload.machine_id).toBe("machine-456");
+    expect(events).toHaveLength(0); // no send
+  });
+});
+
+// ── AC5: machine_id file mode 0600 + only when enabled ──
+
+describe("machine_id (AC5)", () => {
+  it("creates telemetry-id with mode 0600 when enabled", async () => {
+    const { getMachineId } = await import("../src/global-config.js");
+    const id = getMachineId();
+    expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+
+    const filePath = join(tempHome, ".mex", "telemetry-id");
+    expect(existsSync(filePath)).toBe(true);
+
+    const stat = statSync(filePath);
+    // 0o600 = owner read+write only
+    expect(stat.mode & 0o777).toBe(0o600);
+  });
+
+  it("returns the same id on subsequent calls", async () => {
+    const { getMachineId } = await import("../src/global-config.js");
+    const id1 = getMachineId();
+    const id2 = getMachineId();
+    expect(id1).toBe(id2);
+  });
+});
+
+// ── AC6: transport failure does not throw ──
+
+describe("error swallowing (AC6)", () => {
+  it("capture swallows transport errors", async () => {
+    exitDevRepo(); // need telemetry enabled
+    const { capture, __setTransport } = await import("../src/telemetry/index.js");
+    __setTransport(() => {
+      throw new Error("network failure");
+    });
+
+    // Should not throw
+    expect(() => capture("command_run", "check")).not.toThrow();
+  });
+
+  it("flush swallows errors", async () => {
+    const { flush } = await import("../src/telemetry/index.js");
+    // No client initialized + custom transport = nothing to flush
+    await expect(flush()).resolves.toBeUndefined();
+  });
+});
+
+// ── AC7: dev-repo guard ──
+
+describe("dev-repo guard (AC7)", () => {
+  it("detects MEX_DEV environment variable", async () => {
+    process.env.MEX_DEV = "1";
+    const { isDevRepo } = await import("../src/global-config.js");
+    expect(isDevRepo()).toBe(true);
+  });
+
+  it("detects mex-agent package name with src/cli.ts present", async () => {
+    // Create a fake mex-agent project in temp dir
+    const fakeRepo = mkdtempSync(join(tmpdir(), "mex-dev-guard-"));
+    try {
+      writeFileSync(join(fakeRepo, "package.json"), JSON.stringify({ name: "mex-agent" }));
+      mkdirSync(join(fakeRepo, "src"), { recursive: true });
+      writeFileSync(join(fakeRepo, "src", "cli.ts"), "");
+
+      process.chdir(fakeRepo);
+      const { isDevRepo } = await import("../src/global-config.js");
+      expect(isDevRepo()).toBe(true);
+    } finally {
+      rmSync(fakeRepo, { recursive: true, force: true });
+    }
+  });
+
+  it("does NOT treat a user project merely named \"mex\" as the dev repo", async () => {
+    // The bare "mex" name is too generic to disable a real user's telemetry.
+    const fakeRepo = mkdtempSync(join(tmpdir(), "mex-named-"));
+    try {
+      writeFileSync(join(fakeRepo, "package.json"), JSON.stringify({ name: "mex" }));
+      mkdirSync(join(fakeRepo, "src"), { recursive: true });
+      writeFileSync(join(fakeRepo, "src", "cli.ts"), "");
+
+      process.chdir(fakeRepo);
+      const { isDevRepo } = await import("../src/global-config.js");
+      expect(isDevRepo()).toBe(false);
+    } finally {
+      rmSync(fakeRepo, { recursive: true, force: true });
+    }
+  });
+
+  it("returns false in a non-mex directory", async () => {
+    exitDevRepo(); // temp dir has no package.json
+    const { isDevRepo } = await import("../src/global-config.js");
+    expect(isDevRepo()).toBe(false);
+  });
+});
+
+// ── AC8: config set round-trip ──
+
+describe("config set telemetry round-trip (AC8)", () => {
+  it("off then on round-trips through global config", async () => {
+    exitDevRepo(); // need telemetry enabled by default
+    const { setGlobalConfigKey, readGlobalConfig } = await import("../src/global-config.js");
+    const { isEnabled } = await import("../src/telemetry/index.js");
+
+    // Default: enabled (not in dev repo, no env vars, no config)
+    expect(isEnabled().enabled).toBe(true);
+
+    // Set off
+    setGlobalConfigKey("telemetry", "off");
+    expect(readGlobalConfig().telemetry).toBe("off");
+    expect(isEnabled().enabled).toBe(false);
+    expect(isEnabled().reason).toBe("config");
+
+    // Set on
+    setGlobalConfigKey("telemetry", "on");
+    expect(readGlobalConfig().telemetry).toBe("on");
+    expect(isEnabled().enabled).toBe(true);
+  });
+});
+
+// ── AC9: first-run notice to stderr, not stdout, shown once ──
+
+describe("first-run notice (AC9)", () => {
+  it("prints to stderr on first enabled run with TTY", async () => {
+    exitDevRepo(); // need telemetry enabled
+    const { showFirstRunNotice } = await import("../src/telemetry/index.js");
+
+    // Mock stderr.isTTY
+    const originalIsTTY = process.stderr.isTTY;
+    Object.defineProperty(process.stderr, "isTTY", { value: true, configurable: true });
+
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const stdoutSpy = vi.spyOn(process.stdout, "write");
+
+    try {
+      const shown = showFirstRunNotice();
+      expect(shown).toBe(true);
+      expect(stderrSpy).toHaveBeenCalled();
+      expect(stdoutSpy).not.toHaveBeenCalled();
+
+      // Check it contains opt-out instructions
+      const output = stderrSpy.mock.calls.map(c => c[0]).join("");
+      expect(output).toContain("mex config set telemetry off");
+      expect(output).toContain("DO_NOT_TRACK");
+    } finally {
+      Object.defineProperty(process.stderr, "isTTY", { value: originalIsTTY, configurable: true });
+    }
+  });
+
+  it("is not shown on the second run", async () => {
+    exitDevRepo();
+    const { showFirstRunNotice } = await import("../src/telemetry/index.js");
+
+    const originalIsTTY = process.stderr.isTTY;
+    Object.defineProperty(process.stderr, "isTTY", { value: true, configurable: true });
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    try {
+      showFirstRunNotice(); // first
+      stderrSpy.mockClear();
+      const shown = showFirstRunNotice(); // second
+      expect(shown).toBe(false);
+      expect(stderrSpy).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(process.stderr, "isTTY", { value: originalIsTTY, configurable: true });
+    }
+  });
+
+  it("is not shown when telemetry is disabled", async () => {
+    process.env.DO_NOT_TRACK = "1";
+    const { showFirstRunNotice } = await import("../src/telemetry/index.js");
+
+    const originalIsTTY = process.stderr.isTTY;
+    Object.defineProperty(process.stderr, "isTTY", { value: true, configurable: true });
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    try {
+      const shown = showFirstRunNotice();
+      expect(shown).toBe(false);
+      expect(stderrSpy).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(process.stderr, "isTTY", { value: originalIsTTY, configurable: true });
+    }
+  });
+});
+
+// ── AC10: no I/O at import time ──
+
+describe("no I/O at import time (AC10)", () => {
+  it("importing the module does not create files or make network calls", () => {
+    // The module is already imported — check that no ~/.mex/ was created
+    // in a fresh temp home before any explicit call
+    const freshHome = mkdtempSync(join(tmpdir(), "mex-import-"));
+    expect(existsSync(join(freshHome, ".mex"))).toBe(false);
+    rmSync(freshHome, { recursive: true, force: true });
+  });
+});
+
+// ── captureCommand: PII firewall ──
+
+describe("captureCommand PII firewall", () => {
+  it("sends only the scaffold_id string, not identity object fields", async () => {
+    exitDevRepo(); // need telemetry enabled
+    const { captureCommand, __setTransport } = await import("../src/telemetry/index.js");
+    const events: Array<{ event: string; properties: Record<string, unknown> }> = [];
+    __setTransport((event, properties) => events.push({ event, properties }));
+
+    captureCommand("check", "some-uuid-here");
+
+    expect(events).toHaveLength(1);
+    const props = events[0].properties;
+    expect(props.scaffold_id).toBe("some-uuid-here");
+    expect(props.command).toBe("check");
+    expect(props).not.toHaveProperty("scaffold_name");
+    expect(props).not.toHaveProperty("origin");
+    expect(props).not.toHaveProperty("upstream");
+  });
+});
+
+// ── readMachineId: read-only, never plants the tracking file ──
+
+describe("readMachineId (read-only)", () => {
+  it("returns undefined and does NOT create telemetry-id when absent", async () => {
+    const { readMachineId } = await import("../src/global-config.js");
+    expect(readMachineId()).toBeUndefined();
+    expect(existsSync(join(tempHome, ".mex", "telemetry-id"))).toBe(false);
+  });
+
+  it("returns an existing id without creating a new one", async () => {
+    const { getMachineId, readMachineId } = await import("../src/global-config.js");
+    const created = getMachineId();
+    expect(readMachineId()).toBe(created);
+  });
+});
+
+// ── readScaffoldId: read-only, no mint ──
+
+describe("readScaffoldId (read-only)", () => {
+  it("returns scaffold_id from existing config without minting", async () => {
+    const { readScaffoldId } = await import("../src/config.js");
+    const fixture = mkdtempSync(join(tmpdir(), "mex-readonly-"));
+    const scaffoldRoot = join(fixture, ".mex");
+    mkdirSync(scaffoldRoot, { recursive: true });
+    writeFileSync(join(scaffoldRoot, "ROUTER.md"), "");
+    writeFileSync(
+      join(scaffoldRoot, "config.json"),
+      JSON.stringify({ scaffold_id: "existing-id-123", scaffold_name: "my-project" }),
+    );
+
+    try {
+      const id = readScaffoldId(scaffoldRoot);
+      expect(id).toBe("existing-id-123");
+    } finally {
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+
+  it("returns undefined when no scaffold_id exists (does not mint)", async () => {
+    const { readScaffoldId } = await import("../src/config.js");
+    const fixture = mkdtempSync(join(tmpdir(), "mex-noid-"));
+    const scaffoldRoot = join(fixture, ".mex");
+    mkdirSync(scaffoldRoot, { recursive: true });
+    writeFileSync(join(scaffoldRoot, "config.json"), JSON.stringify({ aiTools: ["claude"] }));
+
+    try {
+      const id = readScaffoldId(scaffoldRoot);
+      expect(id).toBeUndefined();
+
+      // Verify no scaffold_id was written
+      const config = JSON.parse(readFileSync(join(scaffoldRoot, "config.json"), "utf-8"));
+      expect(config).not.toHaveProperty("scaffold_id");
+    } finally {
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -368,12 +368,13 @@ describe("first-run notice (AC9)", () => {
 // ── AC10: no I/O at import time ──
 
 describe("no I/O at import time (AC10)", () => {
-  it("importing the module does not create files or make network calls", () => {
-    // The module is already imported — check that no ~/.mex/ was created
-    // in a fresh temp home before any explicit call
-    const freshHome = mkdtempSync(join(tmpdir(), "mex-import-"));
-    expect(existsSync(join(freshHome, ".mex"))).toBe(false);
-    rmSync(freshHome, { recursive: true, force: true });
+  it("re-importing the telemetry module creates nothing under HOME", async () => {
+    // HOME is a fresh temp dir (beforeEach). Force a full re-evaluation of the
+    // module and assert it touched no disk — guards against someone adding a
+    // getMachineId()/readGlobalConfig() call at module top-level.
+    vi.resetModules();
+    await import("../src/telemetry/index.js");
+    expect(existsSync(join(tempHome, ".mex"))).toBe(false);
   });
 });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    // Tests must NEVER emit real telemetry to PostHog. The dev-repo guard only
+    // catches commands run from inside this repo; tests spawn the built CLI in
+    // temp dirs where that guard does not fire, so disable telemetry globally.
+    // Subprocesses spawned with `{ ...process.env }` inherit this.
+    // telemetry.test.ts manages MEX_TELEMETRY itself for its enable-path cases.
+    env: {
+      MEX_TELEMETRY: "0",
+    },
+  },
+});


### PR DESCRIPTION
Stacked on #73 (E1 — scaffold identity). **Base this review against the E1 branch**; once #73 merges to `main`, GitHub will retarget this PR to `main` automatically. The telemetry layer needs E1's `scaffold_id` as its grouping key.

## What

A thin, anonymous, opt-out telemetry layer that counts command usage. All PostHog-specific code lives behind `src/telemetry/index.ts` so the backend can be swapped in one file.

## Trust properties

- **Whitelist payload only:** `machine_id`, `scaffold_id`, `command` name, `mex_version`, `os`, `node_version`. No args, paths, file contents, repo names, IP, or location (`disableGeoip` is set so PostHog never derives geo from the request IP).
- **Opt out four ways:** `DO_NOT_TRACK=1`, `MEX_TELEMETRY=0`, `mex config set telemetry off`, and a dev-repo guard that hard-disables when run from a clone of mex itself (checked before any disk read).
- **No fingerprint when off:** `machine_id` (random UUID at `~/.mex/telemetry-id`, mode 0600) is created only when enabled.
- **PII firewall:** `scaffold_id` is passed as a string only — never the identity object — so `scaffold_name`/`origin`/`upstream` cannot leak.
- **Never breaks a command:** capture fires in a `preAction` hook (so commands that `process.exit`, like `check` on drift, are still counted); flush is best-effort and bounded; all errors swallowed.
- **Auditable:** `mex telemetry inspect` prints the exact would-be payload without sending (and without minting the machine-id file); `mex telemetry status` shows state + active opt-out reason; one-time first-run notice to stderr.

## Tests / docs

219 tests pass, typecheck clean. The suite can never emit real events (`vitest.config.ts` sets `MEX_TELEMETRY=0`). Adds `TELEMETRY.md`, a README link, and a CHANGELOG entry.

## Note

The embedded `phc_...` key is PostHog's write-only ingestion key, documented as safe to ship in client code.
