### PR TITLE
feat: opt-in feedback command and invite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- **Feedback command** — `mex feedback` opens a hosted form for users to opt in to maintainer user-research calls. A quiet, dismissible one-line invite appears after a successful `check`/`sync` and in the `mex` TUI (TTY-only, shown a few times then stops). The CLI never reads or transmits an email — it only opens the URL. Hide it with `mex config set feedback off`. Kept fully separate from telemetry.
 - **Anonymous telemetry** — opt-out usage counting via PostHog. Each command sends one event with only `machine_id`, `scaffold_id`, `command` name, `mex_version`, `os`, and `node_version` — no args, paths, file contents, repo names, IP, or location. Opt out with `DO_NOT_TRACK=1`, `MEX_TELEMETRY=0`, or `mex config set telemetry off`. Audit the exact payload with `mex telemetry inspect`; check state with `mex telemetry status`. Telemetry is disabled automatically when running from a clone of the mex repo. See [TELEMETRY.md](TELEMETRY.md).
-- **Scaffold identity** — `.mex/config.json` now carries a stable `scaffold_id` (UUID v4), `scaffold_name`, and nullable `origin`/`upstream`. Generated at `mex setup` and silently backfilled for existing scaffolds on the next CLI invocation. New `getScaffoldIdentity()` export on the public API.
+- **Scaffold identity** — the scaffold's `config.json` now carries a stable `scaffold_id` (UUID v4), `scaffold_name`, and nullable `origin`/`upstream`. Generated at `mex setup` and silently backfilled for existing scaffolds on the next CLI invocation. New `getScaffoldIdentity()` export on the public API.
 - **broken-link drift checker** — flags Markdown links in scaffold files whose local target file does not exist.
 
 ### Changed

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -162,10 +162,11 @@ program
         return;
       }
 
-      // Warm moment — the user just got a drift result. Quietly invite feedback.
-      maybeShowInvite();
-
       if (hasErrors) process.exit(1);
+
+      // Warm moment — a clean check just gave the user value. Quietly invite
+      // feedback (only on success, never right before an error exit).
+      maybeShowInvite();
     } catch (err) {
       console.error((err as Error).message);
       process.exit(1);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@ import { reportConsole, reportQuiet, reportJSON, reportVerbose } from "./reporte
 import { VERSION } from "./version.js";
 import { captureCommand, flush, isEnabled, getPayloadPreview, showFirstRunNotice } from "./telemetry/index.js";
 import { readMachineId, setGlobalConfigKey } from "./global-config.js";
+import { runFeedback, maybeShowInvite, dismissInvite, enableInvite } from "./feedback/index.js";
 
 /**
  * Load config for a CLI command and backfill scaffold identity on the way.
@@ -161,6 +162,9 @@ program
         return;
       }
 
+      // Warm moment — the user just got a drift result. Quietly invite feedback.
+      maybeShowInvite();
+
       if (hasErrors) process.exit(1);
     } catch (err) {
       console.error((err as Error).message);
@@ -265,6 +269,7 @@ program
       const config = loadConfig();
       const { runSync } = await import("./sync/index.js");
       await runSync(config, { dryRun: opts.dryRun, includeWarnings: opts.warnings });
+      maybeShowInvite();
     } catch (err) {
       console.error((err as Error).message);
       process.exit(1);
@@ -382,14 +387,31 @@ configCmd
         }
         setGlobalConfigKey("telemetry", value);
         console.log(`Telemetry set to "${value}" in ~/.mex/config.json`);
+      } else if (key === "feedback") {
+        if (value !== "on" && value !== "off") {
+          console.error(`Invalid value "${value}" for feedback. Use "on" or "off".`);
+          process.exit(1);
+        }
+        // "off" hides the invite; "on" re-enables it.
+        if (value === "off") dismissInvite();
+        else enableInvite();
+        console.log(`Feedback invite ${value === "off" ? "hidden" : "re-enabled"}.`);
       } else {
-        console.error(`Unknown config key "${key}". Supported keys: telemetry`);
+        console.error(`Unknown config key "${key}". Supported keys: telemetry, feedback`);
         process.exit(1);
       }
     } catch (err) {
       console.error((err as Error).message);
       process.exit(1);
     }
+  });
+
+// ── Feedback ──
+program
+  .command("feedback")
+  .description("Open the mex feedback form (the maintainer is doing user research calls)")
+  .action(() => {
+    runFeedback();
   });
 
 // ── Quick Reference ──
@@ -421,6 +443,7 @@ program
     console.log("  mex telemetry inspect  Show the exact telemetry payload (without sending)");
     console.log("  mex telemetry status   Show telemetry enabled/disabled and reason");
     console.log("  mex config set <k> <v> Set a global config value (e.g. telemetry off)");
+    console.log("  mex feedback           Open the feedback form (the maintainer does user calls)");
     console.log();
     console.log(chalk.dim("Not installed globally? Replace 'mex' with 'npx mex-agent'."));
     console.log();
@@ -455,7 +478,7 @@ function buildCompletion(shell: string): string {
   const commands = [
     "setup", "check", "init", "sync", "pattern", "log", "timeline",
     "heartbeat", "doctor", "watch", "tui", "commands", "completion",
-    "telemetry", "config",
+    "telemetry", "config", "feedback",
   ];
   if (shell === "bash") {
     return `_mex_completion() {

--- a/src/config.ts
+++ b/src/config.ts
@@ -275,13 +275,16 @@ export function saveScaffoldIdentity(scaffoldRoot: string, identity: ScaffoldIde
  */
 export function ensureScaffoldIdentity(scaffoldRoot: string, projectRoot: string): ScaffoldIdentity {
   const existing = loadScaffoldIdentity(loadPersistedConfig(scaffoldRoot));
-  if (existing) return existing;
+  // A complete identity needs both an id and a name. If a prior write or a
+  // hand-edited config left scaffold_name empty, keep the existing id and
+  // backfill only the missing name — never regenerate the id.
+  if (existing && existing.scaffold_name) return existing;
 
   const identity: ScaffoldIdentity = {
-    scaffold_id: randomUUID(),
+    scaffold_id: existing?.scaffold_id ?? randomUUID(),
     scaffold_name: basename(projectRoot),
-    origin: null,
-    upstream: null,
+    origin: existing?.origin ?? null,
+    upstream: existing?.upstream ?? null,
   };
   try {
     saveScaffoldIdentity(scaffoldRoot, identity);
@@ -295,7 +298,7 @@ export function ensureScaffoldIdentity(scaffoldRoot: string, projectRoot: string
  * COMPATIBILITY.md — part of the public API surface.
  */
 export function getScaffoldIdentity(config: MexConfig): ScaffoldIdentity {
-  if (config.identity) return config.identity;
+  if (config.identity && config.identity.scaffold_name) return config.identity;
   const identity = ensureScaffoldIdentity(config.scaffoldRoot, config.projectRoot);
   config.identity = identity;
   return identity;

--- a/src/feedback/index.ts
+++ b/src/feedback/index.ts
@@ -1,0 +1,127 @@
+/**
+ * Opt-in feedback — a path to humans, kept fully separate from telemetry.
+ *
+ * Trust constraint: this module NEVER reads, prompts for, or transmits an
+ * email or any user-identifying data. Its only outbound action is opening a
+ * hosted form URL in the browser; the email is entered by the user on that web
+ * page, never by the CLI. Nothing here touches or joins the telemetry path —
+ * this module does not import the telemetry module, and vice versa.
+ */
+
+import { spawn } from "node:child_process";
+import { platform } from "node:os";
+import { readGlobalConfig, setGlobalConfigKey } from "../global-config.js";
+
+/** Hosted form the maintainer uses for user-research sign-ups. */
+export const FEEDBACK_FORM_URL = "https://tally.so/r/KYGGbK";
+
+/** One-line nudge surfaced at warm moments. Points at the command, never asks for data. */
+export const INVITE_TEXT =
+  "mex is building team features — the maintainer is doing user calls. Interested? Run `mex feedback`.";
+
+/** Max times the invite is surfaced before we stop on our own (don't nag). */
+const INVITE_MAX_SHOWS = 3;
+
+// ── Browser opener (with test seam) ──
+
+type OpenerFn = (url: string) => void;
+let customOpener: OpenerFn | null = null;
+
+/** Test seam: inject a fake opener so tests never spawn a real browser. */
+export function __setOpener(fn: OpenerFn | null): void {
+  customOpener = fn;
+}
+
+function defaultOpen(url: string): void {
+  const os = platform();
+  const [cmd, args] =
+    os === "darwin" ? ["open", [url]] as const :
+    os === "win32" ? ["cmd", ["/c", "start", "", url]] as const :
+    ["xdg-open", [url]] as const;
+  const child = spawn(cmd, args, { stdio: "ignore", detached: true });
+  // No browser / no DISPLAY — swallow; opening is best-effort.
+  child.on("error", () => {});
+  child.unref();
+}
+
+function openUrl(url: string): void {
+  try {
+    (customOpener ?? defaultOpen)(url);
+  } catch {
+    // Opening a browser must never throw.
+  }
+}
+
+// ── `mex feedback` ──
+
+/**
+ * Open the feedback form in the browser. Engaging dismisses the invite so the
+ * nudge stops. The CLI never collects or transmits an email — the form does.
+ */
+export function runFeedback(): void {
+  console.log("Opening the mex feedback form in your browser...");
+  console.log(`If it doesn't open, visit: ${FEEDBACK_FORM_URL}`);
+  openUrl(FEEDBACK_FORM_URL);
+  dismissInvite();
+}
+
+// ── Invite state ──
+
+export function isInviteDismissed(): boolean {
+  try {
+    return readGlobalConfig().feedbackDismissed === true;
+  } catch {
+    return false;
+  }
+}
+
+export function dismissInvite(): void {
+  try {
+    setGlobalConfigKey("feedbackDismissed", true);
+  } catch {
+    // Best-effort; never break a command over the invite.
+  }
+}
+
+/** Re-enable the invite (e.g. `mex config set feedback on`). */
+export function enableInvite(): void {
+  try {
+    setGlobalConfigKey("feedbackDismissed", false);
+    setGlobalConfigKey("feedbackInviteCount", 0);
+  } catch {
+    // Best-effort.
+  }
+}
+
+/**
+ * Whether to surface the one-line invite right now. TTY-only (never in pipes or
+ * CI), suppressed once dismissed or after INVITE_MAX_SHOWS shows.
+ */
+export function shouldShowInvite(): boolean {
+  try {
+    if (!process.stdout.isTTY) return false;
+    const cfg = readGlobalConfig();
+    if (cfg.feedbackDismissed === true) return false;
+    const count = typeof cfg.feedbackInviteCount === "number" ? cfg.feedbackInviteCount : 0;
+    return count < INVITE_MAX_SHOWS;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Print the invite to **stderr** (so it never corrupts machine-readable stdout
+ * like `check --json`) and record that it was shown. No-op when the invite
+ * should not show. Returns true if it was printed.
+ */
+export function maybeShowInvite(): boolean {
+  if (!shouldShowInvite()) return false;
+  try {
+    process.stderr.write(`\n  ${INVITE_TEXT}\n  (hide: mex config set feedback off)\n\n`);
+    const count = readGlobalConfig().feedbackInviteCount;
+    setGlobalConfigKey("feedbackInviteCount", (typeof count === "number" ? count : 0) + 1);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/feedback/index.ts
+++ b/src/feedback/index.ts
@@ -110,6 +110,20 @@ export function shouldShowInvite(): boolean {
 }
 
 /**
+ * Record that the invite was surfaced (bumps the counter toward
+ * INVITE_MAX_SHOWS). Best-effort, no output — safe to call from any surface
+ * (CLI or TUI) so the show-cap applies consistently.
+ */
+export function recordInviteShown(): void {
+  try {
+    const count = readGlobalConfig().feedbackInviteCount;
+    setGlobalConfigKey("feedbackInviteCount", (typeof count === "number" ? count : 0) + 1);
+  } catch {
+    // Best-effort.
+  }
+}
+
+/**
  * Print the invite to **stderr** (so it never corrupts machine-readable stdout
  * like `check --json`) and record that it was shown. No-op when the invite
  * should not show. Returns true if it was printed.
@@ -118,8 +132,7 @@ export function maybeShowInvite(): boolean {
   if (!shouldShowInvite()) return false;
   try {
     process.stderr.write(`\n  ${INVITE_TEXT}\n  (hide: mex config set feedback off)\n\n`);
-    const count = readGlobalConfig().feedbackInviteCount;
-    setGlobalConfigKey("feedbackInviteCount", (typeof count === "number" ? count : 0) + 1);
+    recordInviteShown();
     return true;
   } catch {
     return false;

--- a/src/global-config.ts
+++ b/src/global-config.ts
@@ -70,6 +70,8 @@ export function getMachineId(): string {
 interface GlobalConfig {
   telemetry?: "on" | "off";
   firstRunNoticeShown?: boolean;
+  feedbackDismissed?: boolean;
+  feedbackInviteCount?: number;
   [key: string]: unknown;
 }
 

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -6,6 +6,7 @@ import { findConfig } from "./config.js";
 import { runDriftCheck } from "./drift/index.js";
 import { checkHeartbeat, type HeartbeatResult } from "./heartbeat.js";
 import { appendEvent, readEvents, type EventEntry, type EventKind } from "./events.js";
+import { isInviteDismissed, INVITE_TEXT } from "./feedback/index.js";
 
 const h = React.createElement;
 
@@ -197,6 +198,9 @@ function TuiApp({ config }: { config: MexConfig }) {
       ),
     ),
     h(Box, { marginTop: 1 }, h(Text, { dimColor: true }, "↑/↓ choose · enter run · r refresh · l log · esc dashboard · q quit")),
+    isInviteDismissed()
+      ? null
+      : h(Box, { marginTop: 1 }, h(Text, { color: COLORS.crab }, `✨ ${INVITE_TEXT}`)),
   );
 }
 

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -6,7 +6,7 @@ import { findConfig } from "./config.js";
 import { runDriftCheck } from "./drift/index.js";
 import { checkHeartbeat, type HeartbeatResult } from "./heartbeat.js";
 import { appendEvent, readEvents, type EventEntry, type EventKind } from "./events.js";
-import { isInviteDismissed, INVITE_TEXT } from "./feedback/index.js";
+import { shouldShowInvite, recordInviteShown, INVITE_TEXT } from "./feedback/index.js";
 
 const h = React.createElement;
 
@@ -83,6 +83,7 @@ function TuiApp({ config }: { config: MexConfig }) {
     logFile: "",
     notice: null,
   });
+  const [inviteVisible, setInviteVisible] = useState(false);
 
   const refresh = async (view: View = "dashboard", notice: string | null = null) => {
     setState((s) => ({ ...s, view, loadState: "loading", error: null, notice }));
@@ -96,6 +97,16 @@ function TuiApp({ config }: { config: MexConfig }) {
 
   useEffect(() => {
     void refresh();
+  }, []);
+
+  // Surface the feedback invite once per TUI session, respecting the same cap
+  // and dismissal rules as the CLI nudge (recording the show in a effect, never
+  // during render).
+  useEffect(() => {
+    if (shouldShowInvite()) {
+      recordInviteShown();
+      setInviteVisible(true);
+    }
   }, []);
 
   useInput((input, key) => {
@@ -198,9 +209,9 @@ function TuiApp({ config }: { config: MexConfig }) {
       ),
     ),
     h(Box, { marginTop: 1 }, h(Text, { dimColor: true }, "↑/↓ choose · enter run · r refresh · l log · esc dashboard · q quit")),
-    isInviteDismissed()
-      ? null
-      : h(Box, { marginTop: 1 }, h(Text, { color: COLORS.crab }, `✨ ${INVITE_TEXT}`)),
+    inviteVisible
+      ? h(Box, { marginTop: 1 }, h(Text, { color: COLORS.crab }, `✨ ${INVITE_TEXT}`))
+      : null,
   );
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,7 +48,7 @@ export interface HeartbeatConfig {
 }
 
 /**
- * Stable identity for a mex scaffold. Persisted in `.mex/config.json` and used
+ * Stable identity for a mex scaffold. Persisted in the scaffold's `config.json` and used
  * as the grouping key for anonymous telemetry (one scaffold = one project).
  * `scaffold_id` is a random UUID v4 — never derived from path, repo, or git.
  */

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -301,6 +301,23 @@ describe("scaffold identity", () => {
     expect(raw.scaffold_id).toBe(id.scaffold_id);
     expect(raw.aiTools).toEqual(["claude"]); // existing keys untouched
   });
+
+  it("backfills an empty scaffold_name without regenerating the id", () => {
+    mkdirSync(join(tmpDir, ".git"));
+    const mexPath = join(tmpDir, ".mex");
+    mkdirSync(mexPath);
+    writeFileSync(join(mexPath, "ROUTER.md"), "");
+    // scaffold_id present but no scaffold_name (e.g. hand-edited / partial write)
+    writeFileSync(join(mexPath, "config.json"), JSON.stringify({ scaffold_id: "keep-this-id" }));
+
+    const id = getScaffoldIdentity(findConfig(tmpDir));
+    expect(id.scaffold_id).toBe("keep-this-id"); // id preserved, never regenerated
+    expect(id.scaffold_name).toBe(basename(tmpDir)); // name backfilled to the default
+
+    const raw = JSON.parse(readFileSync(join(mexPath, "config.json"), "utf-8"));
+    expect(raw.scaffold_id).toBe("keep-this-id");
+    expect(raw.scaffold_name).toBe(basename(tmpDir));
+  });
 });
 
 describe("saveAiTools", () => {

--- a/test/feedback.test.ts
+++ b/test/feedback.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// Each test gets a fresh $HOME so the global config (invite state) is isolated,
+// and controls process.stdout.isTTY for the gating checks.
+
+let originalHome: string | undefined;
+let tempHome: string;
+let originalIsTTY: boolean | undefined;
+
+function setTTY(value: boolean): void {
+  Object.defineProperty(process.stdout, "isTTY", { value, configurable: true });
+}
+
+beforeEach(() => {
+  originalHome = process.env.HOME;
+  originalIsTTY = process.stdout.isTTY;
+  tempHome = mkdtempSync(join(tmpdir(), "mex-fb-"));
+  process.env.HOME = tempHome;
+});
+
+afterEach(async () => {
+  process.env.HOME = originalHome;
+  Object.defineProperty(process.stdout, "isTTY", { value: originalIsTTY, configurable: true });
+  const fb = await import("../src/feedback/index.js");
+  fb.__setOpener(null);
+  rmSync(tempHome, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe("FEEDBACK_FORM_URL", () => {
+  it("points at the maintainer's hosted form", async () => {
+    const { FEEDBACK_FORM_URL } = await import("../src/feedback/index.js");
+    expect(FEEDBACK_FORM_URL).toBe("https://tally.so/r/KYGGbK");
+  });
+});
+
+describe("mex feedback", () => {
+  it("opens the form URL (and the CLI never reads an email)", async () => {
+    const { runFeedback, __setOpener } = await import("../src/feedback/index.js");
+    const opened: string[] = [];
+    __setOpener((url) => opened.push(url));
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    runFeedback();
+    expect(opened).toEqual(["https://tally.so/r/KYGGbK"]);
+  });
+
+  it("swallows opener errors (no browser / no DISPLAY)", async () => {
+    const { runFeedback, __setOpener } = await import("../src/feedback/index.js");
+    __setOpener(() => {
+      throw new Error("no browser");
+    });
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    expect(() => runFeedback()).not.toThrow();
+  });
+
+  it("dismisses the invite once the user engages", async () => {
+    const { runFeedback, isInviteDismissed, __setOpener } = await import("../src/feedback/index.js");
+    __setOpener(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    expect(isInviteDismissed()).toBe(false);
+    runFeedback();
+    expect(isInviteDismissed()).toBe(true);
+  });
+});
+
+describe("invite gating", () => {
+  it("never shows in a non-TTY (pipes / CI)", async () => {
+    setTTY(false);
+    const { shouldShowInvite } = await import("../src/feedback/index.js");
+    expect(shouldShowInvite()).toBe(false);
+  });
+
+  it("shows in a fresh TTY, then stays hidden once dismissed", async () => {
+    setTTY(true);
+    const { shouldShowInvite, dismissInvite } = await import("../src/feedback/index.js");
+    expect(shouldShowInvite()).toBe(true);
+    dismissInvite();
+    expect(shouldShowInvite()).toBe(false);
+  });
+
+  it("stops after a few shows so it never nags", async () => {
+    setTTY(true);
+    const { shouldShowInvite, maybeShowInvite } = await import("../src/feedback/index.js");
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    let shows = 0;
+    for (let i = 0; i < 10; i++) if (maybeShowInvite()) shows++;
+    expect(shows).toBe(3); // INVITE_MAX_SHOWS
+    expect(shouldShowInvite()).toBe(false);
+  });
+
+  it("writes the invite to stderr, never stdout", async () => {
+    setTTY(true);
+    const { maybeShowInvite } = await import("../src/feedback/index.js");
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    expect(maybeShowInvite()).toBe(true);
+    expect(stderrSpy).toHaveBeenCalled();
+    expect(stdoutSpy).not.toHaveBeenCalled();
+  });
+
+  it("re-enables via `config set feedback on`", async () => {
+    setTTY(true);
+    const { dismissInvite, enableInvite, shouldShowInvite } = await import("../src/feedback/index.js");
+    dismissInvite();
+    expect(shouldShowInvite()).toBe(false);
+    enableInvite();
+    expect(shouldShowInvite()).toBe(true);
+  });
+});


### PR DESCRIPTION
The third and final piece of the telemetry + feedback handoff. Branches off `main` (E1 #73 and telemetry #74 are merged).

## What

- **`mex feedback`** opens a hosted form (`FEEDBACK_FORM_URL` → Tally) in the browser so users can opt in to maintainer user-research calls.
- A quiet, **dismissible** one-line invite appears after a successful `check`/`sync` and in the bare-`mex` TUI.

## Trust properties

- **The CLI never collects, prompts for, or transmits an email** — its job ends at opening the URL. The email is entered by the user on the web form only.
- **Fully separate from telemetry:** the feedback module does not import the telemetry module (or vice versa), and no feedback value ever enters the telemetry payload.
- **Doesn't nag:** the invite is **TTY-gated** (never in pipes/CI), printed to **stderr** (so it can't corrupt `check --json`), shown a few times then stops on its own. `mex feedback` or `mex config set feedback off` dismisses it for good; `on` re-enables.

## Also folds in the E1 (#73) Copilot review nits

- `ensureScaffoldIdentity`/`getScaffoldIdentity` now backfill an empty `scaffold_name` without regenerating the id.
- Reworded "`.mex/config.json`" → "the scaffold's `config.json`" in the `ScaffoldIdentity` JSDoc and CHANGELOG (the `context/` layout stores config at the repo root).

## Tests

229 pass, typecheck clean. New `test/feedback.test.ts` covers: form URL, opener seam + error swallowing, engage-dismisses-invite, TTY gating, the show-cap, stderr-not-stdout, and re-enable. Plus a regression test for the `scaffold_name` backfill.
