### PR TITLE
chore(release): v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-06-09
+
 ### Added
 - **Feedback command** — `mex feedback` opens a hosted form for users to opt in to maintainer user-research calls. A quiet, dismissible one-line invite appears after a successful `check`/`sync` and in the `mex` TUI (TTY-only, shown a few times then stops). The CLI never reads or transmits an email — it only opens the URL. Hide it with `mex config set feedback off`. Kept fully separate from telemetry.
 - **Anonymous telemetry** — opt-out usage counting via PostHog. Each command sends one event with only `machine_id`, `scaffold_id`, `command` name, `mex_version`, `os`, and `node_version` — no args, paths, file contents, repo names, IP, or location. Opt out with `DO_NOT_TRACK=1`, `MEX_TELEMETRY=0`, or `mex config set telemetry off`. Audit the exact payload with `mex telemetry inspect`; check state with `mex telemetry status`. Telemetry is disabled automatically when running from a clone of the mex repo. See [TELEMETRY.md](TELEMETRY.md).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mex-agent",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mex-agent",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mex-agent",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "CLI engine for mex scaffold — drift detection, pre-analysis, and targeted sync",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Release prep for **v0.6.0**. Bumps `package.json`/lock to 0.6.0 and moves the `[Unreleased]` CHANGELOG block into a dated `[0.6.0] - 2026-06-09` section.

Ships:
- Anonymous, opt-out telemetry (#74) — with `mex telemetry inspect`/`status` and four opt-outs
- Scaffold identity + `getScaffoldIdentity()` public API (#73)
- `mex feedback` command + dismissible invite (#75)
- broken-link drift checker (already merged, previously unreleased)

After merge: `npm publish` from updated `main`, then push the `v0.6.0` tag (and optionally a GitHub release).
