### PR TITLE
fix: detect and launch AI CLIs correctly on Windows (#85)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -981,7 +981,6 @@
       "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -992,7 +991,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1530,7 +1528,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2679,7 +2676,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2729,7 +2725,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2799,7 +2794,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3360,7 +3354,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3491,7 +3484,6 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3747,7 +3739,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "chalk": "^5.4.1",
         "commander": "^13.1.0",
+        "cross-spawn": "^7.0.6",
         "glob": "^11.0.1",
         "ink": "^7.0.3",
         "posthog-node": "^5.21.2",
@@ -26,6 +27,7 @@
         "mex": "dist/cli.js"
       },
       "devDependencies": {
+        "@types/cross-spawn": "^6.0.6",
         "@types/node": "^22.0.0",
         "@types/react": "^19.2.14",
         "ink-testing-library": "^4.0.0",
@@ -925,6 +927,16 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/cross-spawn": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@types/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -969,6 +981,7 @@
       "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -979,6 +992,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1516,6 +1530,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2664,6 +2679,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2713,6 +2729,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2782,6 +2799,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3342,6 +3360,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3472,6 +3491,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3727,6 +3747,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   "dependencies": {
     "chalk": "^5.4.1",
     "commander": "^13.1.0",
+    "cross-spawn": "^7.0.6",
     "glob": "^11.0.1",
     "ink": "^7.0.3",
     "posthog-node": "^5.21.2",
@@ -66,6 +67,7 @@
     "yaml": "^2.7.0"
   },
   "devDependencies": {
+    "@types/cross-spawn": "^6.0.6",
     "@types/node": "^22.0.0",
     "@types/react": "^19.2.14",
     "ink-testing-library": "^4.0.0",

--- a/src/cli-tools.ts
+++ b/src/cli-tools.ts
@@ -1,0 +1,20 @@
+import { execSync } from "node:child_process";
+
+/**
+ * Whether a CLI command is installed and on PATH — cross-platform.
+ *
+ * Windows has no `which`; the equivalent is the built-in `where`. Using `which`
+ * everywhere made detection always throw on Windows, so `mex sync`/`mex setup`
+ * concluded no AI CLI was installed and silently dropped to copy-paste prompts
+ * even when Claude/Codex were present (see issue #85). Only the bare command
+ * name is passed here, so there are no quoting concerns.
+ */
+export function isCliAvailable(cmd: string): boolean {
+  const probe = process.platform === "win32" ? "where" : "which";
+  try {
+    execSync(`${probe} ${cmd}`, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/setup/index.ts
+++ b/src/setup/index.ts
@@ -2,7 +2,8 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync, copyFileSync } from
 import { resolve, dirname, relative, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createInterface } from "node:readline/promises";
-import { execSync, spawn } from "node:child_process";
+import { execSync } from "node:child_process";
+import crossSpawn from "cross-spawn";
 import { stdin, stdout } from "node:process";
 import { globSync } from "glob";
 import chalk from "chalk";
@@ -12,6 +13,7 @@ import {
   buildExistingNoBriefPrompt,
 } from "./prompts.js";
 import { saveAiTools, ensureScaffoldIdentity } from "../config.js";
+import { isCliAvailable } from "../cli-tools.js";
 import type { AiTool } from "../types.js";
 
 // ── Constants ──
@@ -433,19 +435,15 @@ async function selectToolConfig(
 }
 
 function hasClaudeCli(): boolean {
-  try {
-    execSync("which claude", { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
+  return isCliAvailable("claude");
 }
 
 function launchClaude(prompt: string): Promise<void> {
   return new Promise((resolve, reject) => {
-    const child = spawn("claude", [prompt], {
+    // cross-spawn resolves the Windows `claude.cmd` wrapper and escapes the
+    // prompt correctly. Plain spawn threw ENOENT on Windows (issue #85).
+    const child = crossSpawn("claude", [prompt], {
       stdio: "inherit",
-      shell: false,
     });
 
     child.on("close", (code) => {

--- a/src/setup/index.ts
+++ b/src/setup/index.ts
@@ -265,10 +265,18 @@ export async function runSetup(opts: { dryRun?: boolean; mode?: string } = {}): 
     info("You'll see the agent working in real-time.");
     console.log();
 
-    await launchClaude(prompt);
-
-    console.log();
-    ok("Setup complete.");
+    try {
+      await launchClaude(prompt);
+      console.log();
+      ok("Setup complete.");
+    } catch (err) {
+      // A launch/exit failure must not crash setup with an unhandled
+      // rejection — report it and fall back to the manual-paste prompt.
+      console.log();
+      warn(`Couldn't run Claude Code automatically: ${(err as Error).message}`);
+      info("Paste the prompt below into your AI tool to populate the scaffold instead.");
+      printPromptForManualPaste(prompt);
+    }
     await promptGlobalInstall();
     return;
   } else {
@@ -286,14 +294,7 @@ export async function runSetup(opts: { dryRun?: boolean; mode?: string } = {}): 
       info("The agent will read your codebase and fill every scaffold file.");
     }
 
-    console.log();
-    console.log("─────────────────── COPY BELOW THIS LINE ───────────────────");
-    console.log();
-    console.log(prompt);
-    console.log();
-    console.log("─────────────────── COPY ABOVE THIS LINE ───────────────────");
-    console.log();
-    ok("Paste the prompt above into your agent to populate the scaffold.");
+    printPromptForManualPaste(prompt);
   }
 
   await promptGlobalInstall();
@@ -432,6 +433,17 @@ async function selectToolConfig(
   }
 
   return selectedClaude;
+}
+
+function printPromptForManualPaste(prompt: string): void {
+  console.log();
+  console.log("─────────────────── COPY BELOW THIS LINE ───────────────────");
+  console.log();
+  console.log(prompt);
+  console.log();
+  console.log("─────────────────── COPY ABOVE THIS LINE ───────────────────");
+  console.log();
+  ok("Paste the prompt above into your agent to populate the scaffold.");
 }
 
 function hasClaudeCli(): boolean {

--- a/src/sync/index.ts
+++ b/src/sync/index.ts
@@ -1,9 +1,10 @@
 import chalk from "chalk";
-import { spawnSync, execSync } from "node:child_process";
+import crossSpawn from "cross-spawn";
 import { createInterface } from "node:readline";
 import type { MexConfig, SyncTarget, DriftIssue, AiTool } from "../types.js";
 import { AI_TOOLS } from "../types.js";
 import { runDriftCheck } from "../drift/index.js";
+import { isCliAvailable } from "../cli-tools.js";
 import { buildSyncBrief, buildCombinedBrief } from "./brief-builder.js";
 
 function askUser(question: string): Promise<string> {
@@ -16,26 +17,23 @@ function askUser(question: string): Promise<string> {
   });
 }
 
-function hasCliTool(cmd: string): boolean {
-  try {
-    execSync(`which ${cmd}`, { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 function runToolInteractive(tool: AiTool, brief: string, cwd: string): boolean {
   const meta = AI_TOOLS[tool];
   if (!meta.cli) return false;
 
   const args = [...meta.promptFlag, brief];
-  const result = spawnSync(meta.cli, args, {
+  // cross-spawn resolves Windows `.cmd`/`.bat` wrappers (npm installs `claude`
+  // as `claude.cmd`) and escapes args correctly — plain spawnSync throws ENOENT
+  // on Windows, and `shell: true` mangles the multi-line prompt (issue #85).
+  const result = crossSpawn.sync(meta.cli, args, {
     cwd,
     stdio: "inherit",
     timeout: 300_000,
   });
-  return result.status === 0 || result.status === null;
+  // A spawn failure (ENOENT, etc.) sets `error` and leaves `status` null — don't
+  // mistake that for success, or launch problems get silently swallowed.
+  if (result.error) return false;
+  return result.status === 0;
 }
 
 /** Pick which AI tool to use for interactive sync */
@@ -43,14 +41,14 @@ async function pickSyncTool(configuredTools: AiTool[]): Promise<AiTool | null> {
   // Filter to tools that have a CLI and are installed
   let available = configuredTools.filter((t) => {
     const meta = AI_TOOLS[t];
-    return meta.cli && hasCliTool(meta.cli);
+    return meta.cli && isCliAvailable(meta.cli);
   });
 
   // If no configured tools matched, scan for any installed CLI and ask user
   if (available.length === 0) {
     const detected = (Object.keys(AI_TOOLS) as AiTool[]).filter((t) => {
       const meta = AI_TOOLS[t];
-      return meta.cli && hasCliTool(meta.cli);
+      return meta.cli && isCliAvailable(meta.cli);
     });
 
     if (detected.length === 0) return null;

--- a/src/sync/index.ts
+++ b/src/sync/index.ts
@@ -17,7 +17,7 @@ function askUser(question: string): Promise<string> {
   });
 }
 
-function runToolInteractive(tool: AiTool, brief: string, cwd: string): boolean {
+export function runToolInteractive(tool: AiTool, brief: string, cwd: string): boolean {
   const meta = AI_TOOLS[tool];
   if (!meta.cli) return false;
 

--- a/test/cli-tools.test.ts
+++ b/test/cli-tools.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { isCliAvailable } from "../src/cli-tools.js";
+
+describe("isCliAvailable", () => {
+  it("detects a command that is on PATH", () => {
+    // `node` is necessarily present — the test runner is running under it.
+    expect(isCliAvailable("node")).toBe(true);
+  });
+
+  it("returns false for a command that does not exist", () => {
+    expect(isCliAvailable("definitely-not-a-real-cli-xyz123")).toBe(false);
+  });
+
+  it("does not throw on a bogus command (swallows the probe error)", () => {
+    expect(() => isCliAvailable("nope-nope-nope")).not.toThrow();
+  });
+});

--- a/test/sync.test.ts
+++ b/test/sync.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock cross-spawn so we can drive the exact SpawnSyncReturns shapes that
+// `runToolInteractive` must map to a boolean, without launching anything.
+vi.mock("cross-spawn", () => ({
+  default: { sync: vi.fn() },
+}));
+
+import crossSpawn from "cross-spawn";
+import { runToolInteractive } from "../src/sync/index.js";
+
+const mockSync = crossSpawn.sync as unknown as ReturnType<typeof vi.fn>;
+
+describe("runToolInteractive return-value logic", () => {
+  beforeEach(() => {
+    mockSync.mockReset();
+  });
+
+  it("treats a clean exit (status 0) as success", () => {
+    mockSync.mockReturnValue({ status: 0 });
+    expect(runToolInteractive("claude", "brief", process.cwd())).toBe(true);
+  });
+
+  it("treats a non-zero exit (status 1) as failure", () => {
+    mockSync.mockReturnValue({ status: 1 });
+    expect(runToolInteractive("claude", "brief", process.cwd())).toBe(false);
+  });
+
+  it("treats a spawn error / timeout (error set, status null) as failure", () => {
+    mockSync.mockReturnValue({ error: new Error("spawn ENOENT"), status: null });
+    expect(runToolInteractive("claude", "brief", process.cwd())).toBe(false);
+  });
+
+  it("treats a signal kill (status null, no error) as failure", () => {
+    mockSync.mockReturnValue({ status: null, signal: "SIGINT" });
+    expect(runToolInteractive("claude", "brief", process.cwd())).toBe(false);
+  });
+
+  it("returns false without spawning for a tool that has no CLI", () => {
+    // `cursor` is IDE-only (cli: null) — must short-circuit before spawning.
+    expect(runToolInteractive("cursor", "brief", process.cwd())).toBe(false);
+    expect(mockSync).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
 ## What

  Fix AI-CLI detection and launch on Windows. `mex sync` and
  `mex setup` never
  detected an installed AI CLI on Windows, so they silently
  fell back to
  copy-paste prompt mode even when Claude Code / Codex were
  installed.

  - **Detection** used `which`, which doesn't exist on Windows
  (the built-in is
    `where`). `execSync("which <cmd>")` always threw → every
  tool reported as not
    installed. Added `isCliAvailable()` (`src/cli-tools.ts`):
  probes with `where`
    on Windows, `which` elsewhere.
  - **Launch** used `spawn`/`spawnSync`, which throw `ENOENT`
  on the Windows
    `claude.cmd` wrapper. Switched the launch sites to
  `cross-spawn`, which
    resolves `.cmd`/`.bat` wrappers and escapes args correctly
  while keeping the
    multi-line prompt as a single argv element. (The naive
  `shell: true` is worse —
    Node concatenates args unescaped, DEP0190, shattering the
  prompt.)
  - **Robustness:** `runToolInteractive` treated `status ===
  null` (a spawn
    failure) as success, swallowing launch errors. Now returns
  false on
    `result.error` and only treats `status === 0` as success.

  ## Why

  Closes #85

  On Windows, the `which`-based detection made interactive
  sync/setup unusable —
  users were forced into copy-paste mode regardless of which
  AI CLI they had
  installed.

  ## Type of change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor
  - [ ] Docs
  - [ ] CI/Tooling

  ## How to test

  1. On Windows with `claude` installed and on PATH, run `mex
  sync` in a scaffold
     with drift → it now detects "Claude Code" instead of
  printing
     "No supported AI CLI detected. Falling back to prompts
  mode."
  2. Choose interactive (1) → Claude Code launches with the
  fix prompt (no
     `spawn claude ENOENT`).
  3. On macOS/Linux, behavior is unchanged. `npm test` → all
  240 tests pass.

  ## Checklist

  ## Checklist

  - [x] Tests pass (`npm test`)
  - [x] No breaking changes (or documented below)
  - [x] Tested locally with a real project