### PR TITLE
test(graph): expand TS/JS extraction regression fixtures

### DIFF
--- a/src/graph/__tests__/extraction-regression.test.ts
+++ b/src/graph/__tests__/extraction-regression.test.ts
@@ -1,0 +1,149 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { beforeAll, describe, expect, it } from "vitest";
+import { extractFile, loadGrammars } from "../extraction/index.js";
+import type { FileExtraction } from "../extraction/index.js";
+
+const FIXTURES_DIR = join(dirname(fileURLToPath(import.meta.url)), "fixtures");
+
+describe("Graph Extraction Regression", () => {
+  beforeAll(async () => {
+    await loadGrammars(["typescript", "javascript", "tsx", "jsx"]);
+  });
+
+  const extractFixture = (filename: string): FileExtraction => {
+    const path = join(FIXTURES_DIR, filename);
+    const source = readFileSync(path, "utf-8");
+    const result = extractFile(`fixtures/${filename}`, source);
+    expect(result).not.toBeNull();
+    return result!;
+  };
+
+  const node = (result: FileExtraction, kind: string, name: string) =>
+    result.nodes.find((n) => n.kind === kind && n.name === name);
+  const hasEdge = (result: FileExtraction, kind: string, targetName: string) =>
+    result.edges.some((e) => e.kind === kind && e.targetName === targetName);
+  const hasContainsEdge = (result: FileExtraction, sourceId: string, targetId: string) =>
+    result.edges.some((e) => e.kind === "contains" && e.source === sourceId && e.target === targetId);
+
+  describe("TypeScript Edge Cases", () => {
+    let result: FileExtraction;
+    beforeAll(() => {
+      result = extractFixture("typescript-edge-cases.ts");
+    });
+
+    it("detects language correctly", () => {
+      expect(result.language).toBe("typescript");
+    });
+
+    it("extracts interfaces, types, and enums", () => {
+      expect(node(result, "interface", "ProcessorOptions")).toBeDefined();
+      expect(node(result, "type_alias", "Status")).toBeDefined();
+      expect(node(result, "enum", "ErrorCode")).toBeDefined();
+      expect(node(result, "enum_member", "Timeout")).toBeDefined();
+    });
+
+    it("extracts classes with visibility modifiers and return types", () => {
+      const cls = node(result, "class", "Processor");
+      expect(cls).toBeDefined();
+
+      const options = node(result, "property", "options");
+      expect(options).toBeDefined();
+      expect(options!.visibility).toBe("protected");
+
+      const run = node(result, "method", "run");
+      expect(run).toBeDefined();
+      expect(run!.visibility).toBe("public");
+      expect(run!.isAsync).toBe(true);
+      expect(run!.returnType).toBe("Promise<void>");
+    });
+
+    it("captures qualified names and containment", () => {
+      const cls = node(result, "class", "Processor");
+      const run = node(result, "method", "run");
+      expect(run!.qualifiedName).toBe("Processor::run");
+      expect(hasContainsEdge(result, cls!.id, run!.id)).toBe(true);
+    });
+
+    it("captures imports and calls", () => {
+      expect(hasEdge(result, "imports", "external-lib")).toBe(true);
+      expect(hasEdge(result, "calls", "externalHelper")).toBe(true);
+    });
+  });
+
+  describe("JavaScript Edge Cases", () => {
+    let result: FileExtraction;
+    beforeAll(() => {
+      result = extractFixture("javascript-edge-cases.js");
+    });
+
+    it("detects language correctly", () => {
+      expect(result.language).toBe("javascript");
+    });
+
+    it("extracts classes, static methods, and calls", () => {
+      expect(node(result, "class", "Manager")).toBeDefined();
+      
+      const create = node(result, "method", "create");
+      expect(create).toBeDefined();
+      expect(create!.isStatic).toBe(true);
+
+      expect(hasEdge(result, "instantiates", "Manager")).toBe(true);
+      expect(hasEdge(result, "calls", "api.save")).toBe(true);
+    });
+
+    it("degrades gracefully on ambiguous syntax", () => {
+      // The file should parse and extract the valid symbols despite any syntax errors
+      expect(node(result, "function", "withWeirdSyntax")).toBeDefined();
+    });
+  });
+
+  describe("TSX Components", () => {
+    let result: FileExtraction;
+    beforeAll(() => {
+      result = extractFixture("tsx-component.tsx");
+    });
+
+    it("detects language correctly", () => {
+      expect(result.language).toBe("tsx");
+    });
+
+    it("extracts components, arrow functions, and calls", () => {
+      expect(node(result, "interface", "Props")).toBeDefined();
+      expect(node(result, "function", "Widget")).toBeDefined();
+      
+      // Arrow functions inside functions are local variables and are not extracted as nodes
+      // But the calls they make should attribute to the enclosing function
+      expect(hasEdge(result, "calls", "setCount")).toBe(true);
+    });
+
+    it("captures JSX component usage via imports", () => {
+      expect(hasEdge(result, "imports", "react")).toBe(true);
+      expect(hasEdge(result, "imports", "./Header")).toBe(true);
+    });
+  });
+
+  describe("JSX Components", () => {
+    let result: FileExtraction;
+    beforeAll(() => {
+      result = extractFixture("jsx-component.jsx");
+    });
+
+    it("detects language correctly", () => {
+      expect(result.language).toBe("jsx");
+    });
+
+    it("extracts functions and internal arrow functions", () => {
+      const page = node(result, "function", "Page");
+      expect(page).toBeDefined();
+
+      // Local arrow functions are not extracted, but their instantiations attribute to the parent
+      expect(hasEdge(result, "instantiates", "Promise")).toBe(true);
+    });
+
+    it("captures promise instantiations", () => {
+      expect(hasEdge(result, "instantiates", "Promise")).toBe(true);
+    });
+  });
+});

--- a/src/graph/__tests__/fixtures/javascript-edge-cases.js
+++ b/src/graph/__tests__/fixtures/javascript-edge-cases.js
@@ -1,0 +1,33 @@
+import { api } from "./api.js";
+
+// IIFE to test containment and calls
+(function init() {
+  api.setup();
+})();
+
+export const utils = {
+  // Method in object literal
+  format() {
+    return "fmt";
+  }
+};
+
+// Class with static method and private field
+export class Manager {
+  #internalState = 0;
+
+  static create() {
+    return new Manager();
+  }
+
+  update() {
+    this.#internalState++;
+    api.save(this.#internalState);
+  }
+}
+
+// Ambiguous or unsupported syntax that degrades safely
+function withWeirdSyntax() {
+  const x = ; // missing value
+  return x;
+}

--- a/src/graph/__tests__/fixtures/jsx-component.jsx
+++ b/src/graph/__tests__/fixtures/jsx-component.jsx
@@ -1,0 +1,13 @@
+import { Section } from "./Section";
+
+export function Page() {
+  const loadData = () => {
+    return new Promise((resolve) => resolve());
+  };
+
+  return (
+    <main>
+      <Section onMount={loadData} />
+    </main>
+  );
+}

--- a/src/graph/__tests__/fixtures/tsx-component.tsx
+++ b/src/graph/__tests__/fixtures/tsx-component.tsx
@@ -1,0 +1,21 @@
+import React, { useState } from "react";
+import { Header } from "./Header";
+
+interface Props {
+  title: string;
+}
+
+export const Widget: React.FC<Props> = ({ title }) => {
+  const [count, setCount] = useState(0);
+
+  const increment = () => setCount(count + 1);
+
+  return (
+    <div className="widget">
+      <Header title={title} />
+      <button onClick={increment}>Count {count}</button>
+      {/* Ambiguous JSX that safely degrades */}
+      <div data-value={ = } />
+    </div>
+  );
+};

--- a/src/graph/__tests__/fixtures/typescript-edge-cases.ts
+++ b/src/graph/__tests__/fixtures/typescript-edge-cases.ts
@@ -1,0 +1,31 @@
+import { externalHelper } from "external-lib";
+
+export interface ProcessorOptions {
+  timeout: number;
+}
+
+export type Status = "idle" | "running";
+
+export enum ErrorCode {
+  Timeout = 1,
+  Unknown = 2,
+}
+
+export class Processor {
+  private status: Status = "idle";
+  protected options: ProcessorOptions;
+  public id: string;
+
+  constructor(options: ProcessorOptions) {
+    this.options = options;
+    this.id = "proc";
+  }
+
+  public async run(): Promise<void> {
+    this.status = "running";
+    const callback = () => {
+      externalHelper(this.id);
+    };
+    callback();
+  }
+}


### PR DESCRIPTION
## What

Expand graph extraction regression coverage for the existing supported languages by adding focused fixtures and semantic regression tests.

### Added fixtures:
- `src/graph/__tests__/fixtures/typescript-edge-cases.ts`
- `src/graph/__tests__/fixtures/javascript-edge-cases.js`
- `src/graph/__tests__/fixtures/tsx-component.tsx`
- `src/graph/__tests__/fixtures/jsx-component.jsx`

### Added regression test:
- `src/graph/__tests__/extraction-regression.test.ts`

The new tests validate:
- Language detection
- Representative node shapes
- Qualified names
- Containment relationships
- Imports
- Calls
- Safe degradation for malformed/ambiguous syntax

No production graph extraction logic was modified.

---

## Why

Closes #97

This improves regression coverage for the four languages already supported by the code graph preview (TypeScript, JavaScript, TSX, and JSX) while keeping the graph contracts unchanged.

---

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/Tooling

---

## How to test

1. Install dependencies.

```bash
npm ci
```

2. Run type checking.

```bash
npm run typecheck
```

3. Run the focused regression test.

```bash
npx vitest src/graph/__tests__/extraction-regression.test.ts --run
```

Expected result:

- All 14 regression tests pass successfully.

4. Build the project.

```bash
npm run build
```

---

## Checklist

- [x] Relevant regression tests pass locally (`npx vitest src/graph/__tests__/extraction-regression.test.ts --run`)
- [x] No breaking changes
- [x] Tested locally with a real project

---

## Code-graph preview

- [x] This PR targets `code-graph-preview`, not `main`
- [x] The linked issue states `Target branch: code-graph-preview`
- [x] The change follows the frozen `LanguageExtractor` / `FrameworkResolver` interfaces
- [x] A focused fixture and semantic assertions for the expected node/edge shape are included
- [ ] Any new grammar WASM, extension mapping, extractor, or resolver is registered
- [x] No graph identity, reconciliation, schema, or drift-semantics changes are included